### PR TITLE
chore(config): add custom domain route and update spellcheck

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
 	},
 	"cSpell.words": [
 		"contentlayer",
+		"gordonbeeming",
 		"headlessui",
 		"notranslate",
 		"opennextjs"

--- a/wrangler.json
+++ b/wrangler.json
@@ -18,7 +18,13 @@
 	"observability": {
 		"enabled": true
 	},
-	"upload_source_maps": true
+	"upload_source_maps": true,
+	"routes": [
+    {
+      "pattern": "preview.gordonbeeming.com",
+      "custom_domain": true
+    },
+  ]
 	/**
 	 * Smart Placement
 	 * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement


### PR DESCRIPTION
Add a custom domain route for preview.gordonbeeming.com in wrangler.json
to enable deployment on the specified domain. Update VSCode spellcheck
settings to include "gordonbeeming" to prevent false positives during
development. These changes improve deployment configuration and developer
experience.