### PR TITLE
chore: add Husky v9 for Git hooks management

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cross-env": "^7.0.3",
     "eslint": "8.56.0",
     "eslint-config-next": "15.3.3",
+    "husky": "^9.1.7",
     "postcss": "8.5.4",
     "prettier": "^3.5.3",
     "tailwindcss": "4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       eslint-config-next:
         specifier: 15.3.3
         version: 15.3.3(eslint@8.56.0)(typescript@5.8.3)
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       postcss:
         specifier: 8.5.4
         version: 8.5.4
@@ -3244,6 +3247,11 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   hyperdyperid@1.2.0:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
@@ -8651,6 +8659,8 @@ snapshots:
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  husky@9.1.7: {}
 
   hyperdyperid@1.2.0: {}
 


### PR DESCRIPTION
Add Husky as a development dependency to enable Git hooks
management. This change updates the lockfile and package.json
to include Husky v9.1.7, ensuring consistent pre-commit and
other Git hook enforcement across the team.