### PR TITLE
ci: add manual trigger to build-publish workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,6 +1,7 @@
 name: 😱 Build, Publish & Deploy
 
 on:
+  workflow_dispatch:
   push:
     branches: ["main"]
     paths:


### PR DESCRIPTION
Enable workflow_dispatch event to allow manual triggering of the
build, publish, and deploy workflow. This change improves flexibility
by letting users run the workflow on demand, not just on pushes to main.