### PR TITLE
feat: add rehype-external-links to enhance link handling

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -21,6 +21,7 @@ import rehypeKatex from 'rehype-katex'
 import rehypeKatexNoTranslate from 'rehype-katex-notranslate'
 import rehypeCitation from 'rehype-citation'
 import rehypePresetMinify from 'rehype-preset-minify'
+import rehypeExternalLinks from 'rehype-external-links'
 import siteMetadata from './data/siteMetadata'
 import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer.js'
 import prettier from 'prettier'
@@ -260,6 +261,7 @@ export default makeSource({
       rehypeKatex,
       rehypeKatexNoTranslate,
       [rehypeCitation, { path: path.join(root, 'data') }],
+      [rehypeExternalLinks, { target: '_blank', rel: ['nofollow'] }],
       rehypePresetMinify,
     ],
   },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "reading-time": "^1.5.0",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-citation": "^2.3.1",
+    "rehype-external-links": "^3.0.0",
     "rehype-katex": "^7.0.1",
     "rehype-katex-notranslate": "^1.1.4",
     "rehype-preset-minify": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       rehype-citation:
         specifier: ^2.3.1
         version: 2.3.1
+      rehype-external-links:
+        specifier: ^3.0.0
+        version: 3.0.0
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
@@ -3307,6 +3310,10 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  is-absolute-url@4.0.1:
+    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -4302,6 +4309,9 @@ packages:
 
   rehype-citation@2.3.1:
     resolution: {integrity: sha512-bwSuB5SMilyS/vT7K7ByTxjeKda4GWJin6dHKKZyp5O2z+uLk2ySG7a5/IOmuGovoajN9AcYxTRE4kUiVTk51g==}
+
+  rehype-external-links@3.0.0:
+    resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
 
   rehype-katex-notranslate@1.1.4:
     resolution: {integrity: sha512-zr2NMVDnTHAFyyVC14I00NDDlSwjvd//EWzIhazz6eNn34LeJQyFECaRBCVdqBIVA6KMvBooO26pfSZXjUG84Q==}
@@ -8702,6 +8712,8 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  is-absolute-url@4.0.1: {}
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -10069,6 +10081,15 @@ snapshots:
       unist-util-visit: 5.0.0
     transitivePeerDependencies:
       - encoding
+
+  rehype-external-links@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-is-element: 3.0.0
+      is-absolute-url: 4.0.1
+      space-separated-tokens: 2.0.2
+      unist-util-visit: 5.0.0
 
   rehype-katex-notranslate@1.1.4:
     dependencies:


### PR DESCRIPTION
Add rehype-external-links plugin to the content processing pipeline
to automatically set external links to open in a new tab with rel
attributes for SEO and security. Update dependencies and lockfile to
include rehype-external-links and its required packages. This improves
user experience and site security by properly handling external links.