### PR TITLE
ci: enable preview branch deployment in workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -3,7 +3,7 @@ name: 😱 Build, Publish & Deploy
 on:
   workflow_dispatch:
   push:
-    branches: ["main"]
+    branches: ["main", "preview"]
     paths:
       - "data/**"
       - "public/**"
@@ -85,7 +85,7 @@ jobs:
   deploy-preview:
     name: 🕵️ Deploy to Preview
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview'
     runs-on: self-hosted
     environment:
       name: preview


### PR DESCRIPTION
Allow the build-publish workflow to trigger on pushes to the
preview branch in addition to main. Update the deploy-preview job
to run for both main and preview branches. This change enables
testing and deployment of preview changes without affecting main.