### PR TITLE
fix(blog): correct code block formatting in domain models post

### DIFF
--- a/data/blog/2025-08-05/architecting-csharp-domain-models-for-human-and-ai-collaboration.mdx
+++ b/data/blog/2025-08-05/architecting-csharp-domain-models-for-human-and-ai-collaboration.mdx
@@ -51,6 +51,7 @@ order.OrderItems.Add(item);
 // Whoops! This breaks a rule, but the domain can't protect itself.
 // The Order had no say in this change.
 item.Quantity = 5; 
+```
 
 Our goal is to make these invalid states unrepresentable by forcing all interactions to go through controlled methods on the Aggregate Root.
 


### PR DESCRIPTION
Add missing code block delimiter to fix formatting in the example
showing how invalid states can occur in the Order aggregate. This
improves readability and clarity of the explanation about enforcing
invariants through Aggregate Root methods.