### PR TITLE
ci(workflow): trigger build and deploy on copilot branches

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -3,7 +3,7 @@ name: 😱 Build, Publish & Deploy
 on:
   workflow_dispatch:
   push:
-    branches: ["main", "preview"]
+    branches: ["main", "preview", "copilot/*"]
     paths:
       - "data/**"
       - "public/**"
@@ -85,7 +85,7 @@ jobs:
   deploy-preview:
     name: 🕵️ Deploy to Preview
     needs: build
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview' || github.ref == 'refs/heads/copilot/*'
     runs-on: self-hosted
     environment:
       name: preview


### PR DESCRIPTION
Add "copilot/*" branches to the build and deploy workflow triggers to
enable automated CI/CD for feature branches under the copilot namespace.
This ensures changes in these branches run the build and deploy-preview
jobs, improving testing and deployment coverage.