### PR TITLE
ci: fix branch filter syntax in deploy-preview workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -85,7 +85,7 @@ jobs:
   deploy-preview:
     name: 🕵️ Deploy to Preview
     needs: build
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview' || github.ref == 'refs/heads/copilot/*'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview' || startsWith(github.ref, 'refs/heads/copilot/')
     runs-on: self-hosted
     environment:
       name: preview


### PR DESCRIPTION
Update the condition to correctly check for branches starting with
'copilot/' using startsWith function. This ensures the deploy-preview
job triggers as expected on all copilot feature branches.