### PR TITLE
refactor: remove unnecessary async and Promise params in TagPage

### DIFF
--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -10,10 +10,9 @@ import { Metadata } from 'next'
 const POSTS_PER_PAGE = 10
 
 export async function generateMetadata(props: {
-  params: Promise<{ tag: string }>
+  params: { tag: string }
 }): Promise<Metadata> {
-  const params = await props.params
-  const tag = decodeURI(params.tag)
+  const tag = decodeURI(props.params.tag)
   return genPageMetadata({
     title: tag,
     description: `${siteMetadata.title} ${tag} tagged content`,
@@ -34,9 +33,8 @@ export const generateStaticParams = async () => {
   }))
 }
 
-export default async function TagPage(props: { params: Promise<{ tag: string }> }) {
-  const params = await props.params
-  const tag = decodeURI(params.tag)
+export default async function TagPage(props: { params: { tag: string } }) {
+  const tag = decodeURI(props.params.tag)
   const title = `Posts tagged "${tag}"`
   const filteredPosts = allCoreContent(
     sortPosts(allBlogs.filter((post) => post.tags && post.tags.map((t) => slug(t).replace(/--+/g, '-')).includes(tag)))

--- a/src/app/tags/[tag]/page/[page]/page.tsx
+++ b/src/app/tags/[tag]/page/[page]/page.tsx
@@ -19,11 +19,11 @@ export const generateStaticParams = async () => {
   })
 }
 
-export default async function TagPage(props: { params: Promise<{ tag: string; page: string }> }) {
-  const params = await props.params
-  const tag = decodeURI(params.tag)
+// Removed old async TagPage with Promise params. Only the correct function remains below.
+export default function TagPage(props: { params: { tag: string; page: string } }) {
+  const tag = decodeURI(props.params.tag)
   const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
-  const pageNumber = parseInt(params.page)
+  const pageNumber = parseInt(props.params.page)
   const filteredPosts = allCoreContent(
     sortPosts(allBlogs.filter((post) => post.tags && post.tags.map((t) => slug(t).replace(/--+/g, '-')).includes(tag)))
   )


### PR DESCRIPTION
Update TagPage components to accept direct params objects instead of
Promise-wrapped params. This simplifies the code by removing redundant
async/await usage and aligns with the expected props structure. It also
improves readability and consistency across tag-related pages.