### PR TITLE
ci: restrict permissions in deploy jobs for security

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -84,6 +84,7 @@ jobs:
 
   deploy-preview:
     name: 🕵️ Deploy to Preview
+    permissions: {}
     needs: build
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview' || startsWith(github.ref, 'refs/heads/copilot/')
     runs-on: self-hosted
@@ -114,6 +115,7 @@ jobs:
 
   deploy-production:
     name: 🚀 Deploy to Production
+    permissions: {}
     if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: self-hosted


### PR DESCRIPTION
Add empty permissions objects to deploy-preview and deploy-production
jobs in the GitHub Actions workflow to limit default permissions. This
change reduces the risk of unintended access during deployment steps.