### PR TITLE
chore(ci): use full image prune in CI workflows

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Cleanup old Podman images
         run: |
-          podman system prune -f --volumes
+          podman system prune -a --volumes
 
       - name: Deploy to preview environment
         run: |
@@ -130,8 +130,8 @@ jobs:
     steps:
       - name: Cleanup old Podman images
         run: |
-          podman system prune -f --volumes
-          
+          podman system prune -a --volumes
+
       - name: Deploy to production environment
         run: |
           export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$(id -u)/bus"


### PR DESCRIPTION
Change Podman cleanup to run `podman system prune -a --volumes`
instead of `podman system prune -f --volumes` in the build-publish
workflow for both preview and production jobs.

This ensures all unused images, not just dangling ones, are removed
before deployments, preventing disk build-up and reducing the risk of
CI failures due to low disk space. Also remove trailing blank lines
for minor cleanup.