### PR TITLE
chore(ci): add force flag to podman system prune

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Cleanup old Podman images
         run: |
-          podman system prune -a --volumes
+          podman system prune -a -f --volumes
 
       - name: Deploy to preview environment
         run: |
@@ -130,7 +130,7 @@ jobs:
     steps:
       - name: Cleanup old Podman images
         run: |
-          podman system prune -a --volumes
+          podman system prune -a -f --volumes
 
       - name: Deploy to production environment
         run: |


### PR DESCRIPTION
Include -f to make podman system prune-interactive in CI.
This prevents the workflow from blocking when pruning images and volumes
during preview and production deploy steps, ensuring automated
cleanup completes without manual confirmation.