### PR TITLE
fix(footer): display full copyright range and site title

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,9 +20,7 @@ export default function Footer() {
           <SocialIcon kind="medium" href={siteMetadata.medium} size={6} />
         </div>
         <div className="mb-2 flex space-x-2 text-sm text-gray-500 dark:text-gray-400">
-          <div>{siteMetadata.author}</div>
-          <div>{` • `}</div>
-          <div>{`© ${new Date().getFullYear()}`}</div>
+          <div>&copy;{` 2014 - ${new Date().getFullYear()}`}</div>
           <div>{` • `}</div>
           <Link href="/">{siteMetadata.title}</Link>
         </div>


### PR DESCRIPTION
Replace separate author and single-year copyright elements with a
single combined copyright range starting from 2014 through the current
year. Move the site title next to the separator so the footer shows
"© 2014 - <currentYear> • <Site Title>".

This clarifies ownership timeframe and simplifies footer markup by
reducing redundant author output while preserving the link to the site
home.