### PR TITLE
refactor(content): "Why Xylem" quote into author bio

### DIFF
--- a/data/authors/gordon-beeming.mdx
+++ b/data/authors/gordon-beeming.mdx
@@ -20,6 +20,8 @@ Hi, I'm Gordon Beeming! I'm a Solution Architect at SSW in Brisbane, and I'm pas
 
 For me, DevOps is more than just a set of tools—it's a mindset that revolutionizes how we approach software development. I've been working within the Microsoft ecosystem since .NET 2.0 and have been a champion for Azure DevOps since its early days as TFPreview. My dedication to the community and technology has been recognized with the Microsoft MVP award every year since 2014.
 
+> Xylem: Transporting foundational knowledge from root concepts to growing ideas
+
 I've had the incredible opportunity to share my knowledge by co-authoring several books and contributing to ALM Ranger guidance documents. Today, you'll find me designing and building solutions in Azure, helping teams write better C#, and sharing my discoveries on my [YouTube channel](https://www.youtube.com/@gordonbeeming).
 
 Outside of tech, I'm a husband and father who loves to unwind by training for my next swim, bike, or run event.

--- a/src/app/Main.tsx
+++ b/src/app/Main.tsx
@@ -51,18 +51,6 @@ export default function Home({ posts }) {
 
       {/* Content Hub */}
       <div className="space-y-16">
-        {/* Why Xylem Quote */}
-        <section aria-labelledby="why-xylem-heading" className="mb-0">
-          <h2 id="why-xylem-heading" className="sr-only">Why Xylem</h2>
-          <div className="prose dark:prose-invert max-w-none">
-            <blockquote>
-              <p title='Xylem: In plants, xylem is the vascular tissue that transports water and nutrients from roots to the rest of the plant. This is a great metaphor for a blog that disseminates foundational knowledge and supports growth.'>
-                Xylem: Transporting foundational knowledge from root concepts to growing ideas
-              </p>
-            </blockquote>
-          </div>
-        </section>
-
         {/* Latest Blog Posts Section */}
         <section aria-labelledby="blog-posts-heading">
           <div className="mb-8">


### PR DESCRIPTION
Move the standalone "Why Xylem" quote out of the main Content Hub section
and embed it into the Gordon Beeming author bio. This removes a redundant
block-level quote from Main.tsx and consolidates the contextual tagline
with the author's personal page where it is more relevant.

- Remove the Why Xylem quote section from src/app/Main.tsx to declutter
  the homepage content hub.
- Add the same quote line to data/authors/gordon-beeming.mdx so the
  tagline appears in the author's bio and retains informational context.

This keeps the homepage focused on recent content while preserving the
brand/tagline in a location tied to the author.