### PR TITLE
fix(authors): replace em dash with comma in bio

### DIFF
--- a/data/authors/gordon-beeming.mdx
+++ b/data/authors/gordon-beeming.mdx
@@ -18,7 +18,7 @@ github: https://github.com/GordonBeeming
 
 Hi, I'm Gordon Beeming! I'm a Solution Architect at SSW in Brisbane, and I'm passionate about solving complex problems with clean, effective technology.
 
-For me, DevOps is more than just a set of tools—it's a mindset that revolutionizes how we approach software development. I've been working within the Microsoft ecosystem since .NET 2.0 and have been a champion for Azure DevOps since its early days as TFPreview. My dedication to the community and technology has been recognized with the Microsoft MVP award every year since 2014.
+For me, DevOps is more than just a set of tools, it's a mindset that revolutionizes how we approach software development. I've been working within the Microsoft ecosystem since .NET 2.0 and have been a champion for Azure DevOps since its early days as TFPreview. My dedication to the community and technology has been recognized with the Microsoft MVP award every year since 2014.
 
 > Xylem: Transporting foundational knowledge from root concepts to growing ideas
 


### PR DESCRIPTION
Replace an em dash with a comma in Gordon Beeming's author bio to
correct punctuation and align with the project's preferred style.
This change standardizes punctuation across author profiles and avoids
inconsistent typography in the content.