### PR TITLE
💄 Responsive header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,7 +30,7 @@ const Header = () => {
       </Link>
       <nav 
         id="navigation" 
-        className="flex items-center space-x-4 leading-5 sm:-mr-6 sm:space-x-6 flex-shrink-0" 
+        className="flex items-center space-x-4 leading-5 sm:-mr-6 sm:space-x-6 flex-shrink-0 sm:w-full sm:justify-between xl:justify-start xl:w-auto" 
         role="navigation" 
         aria-label="Main navigation"
       >
@@ -47,9 +47,11 @@ const Header = () => {
               </Link>
             ))}
         </div>
-        <SearchButton />
-        <ThemeSwitch />
-        <MobileNav />
+        <div className="flex flex-row flex-end items-center gap-x-4">
+          <SearchButton />
+          <ThemeSwitch />
+          <MobileNav />
+        </div>
       </nav>
     </header>
   )


### PR DESCRIPTION
Before iPad

<img width="1444" height="1444" alt="CleanShot 2025-09-09 at 08 33 34@2x" src="https://github.com/user-attachments/assets/bc1a3b1b-dd11-4895-a58b-f9999a3adb78" />

After iPad

<img width="1560" height="1520" alt="CleanShot 2025-09-09 at 08 33 51@2x" src="https://github.com/user-attachments/assets/b45cbabc-7af4-4a33-a4d0-755575de04f4" />
