### PR TITLE
chore(docker): set timezone in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,9 @@ FROM node:24-alpine AS runner
 
 WORKDIR /app
 
-# Set production environment
+# Set production environment and timezone
 ENV NODE_ENV=production
+ENV TZ="Australia/Brisbane"
 ENV HOSTNAME="0.0.0.0"
 
 # Disable telemetry


### PR DESCRIPTION
Set the container timezone to Australia/Brisbane by adding TZ to the
Dockerfile environment variables. This ensures logs, scheduled tasks,
and any time-sensitive operations inside the production image use the
expected local time. Also keep NODE_ENV=production and HOSTNAME intact.