### PR TITLE
feat(content): enforce timezone-aware date filtering and enable dynamic page

### DIFF
--- a/data/blog/2025-10-03/upgrading-my-wifes-portfolio-to-tinacms-with-the-github-copilot-cli.mdx
+++ b/data/blog/2025-10-03/upgrading-my-wifes-portfolio-to-tinacms-with-the-github-copilot-cli.mdx
@@ -6,6 +6,8 @@ draft: false
 summary: "A task estimated to take 5 hours was to convert my wife's portfolio to use TinaCMS. I decided to see if the new GitHub Copilot CLI could do it for me. The result was surprising."
 ---
 
+🤝 A Human-AI Collaboration - I worked with my AI assistant to bring this post to life. Think of it as a brainstorming partner that helps structure thoughts and smooth out the prose. The core message and the experience behind it? That's all me.
+
 Not long ago, I wrote about how I finally built my wife, [Tiani Beeming](https://tianibeeming.com)'s, portfolio website in about five hours after a 10-year delay, all thanks to an AI-driven workflow. The site looked great, and it was a huge win.
 
 But... there's always a "but", isn't there? 😅

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -23,6 +23,7 @@ const siteMetadata = {
   medium: '',
   bluesky: 'https://bsky.app/profile/gordon.beeming.net',
   locale: 'en-US',
+  timezone: 'Australia/Brisbane', // Timezone for date calculations (AEST/AEDT)
   // set to true if you want a navbar fixed to the top
   stickyNav: true,
   analytics: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,9 @@ import { allBlogs } from 'contentlayer/generated'
 import { filterPublishedPosts } from '@/utils/contentUtils'
 import Main from './Main'
 
+// Force dynamic rendering to ensure date filtering happens at request time
+export const dynamic = 'force-dynamic'
+
 export default async function Page() {
   const filteredBlogs = filterPublishedPosts(allBlogs)
   const sortedPosts = sortPosts(filteredBlogs)

--- a/src/utils/contentUtils.ts
+++ b/src/utils/contentUtils.ts
@@ -1,8 +1,9 @@
 import type { Blog } from 'contentlayer/generated'
+import siteMetadata from '@/data/siteMetadata'
 
 /**
  * Filters out future-dated posts to prevent them from showing in listings and search.
- * Only shows posts that are published (not draft) and have a date <= current date.
+ * Only shows posts that are published (not draft) and have a date <= current date in the configured timezone.
  * 
  * @param posts - Array of blog posts to filter
  * @param options - Configuration options for filtering
@@ -18,8 +19,11 @@ export function filterPublishedPosts(posts: Blog[], options: { includeAllInDev?:
     return posts
   }
   
-  const now = new Date()
-  now.setHours(23, 59, 59, 999) // Set to end of current day to include posts from today
+  // Get current date in the configured timezone (defaults to Australia/Brisbane)
+  const timezone = siteMetadata.timezone || 'Australia/Brisbane'
+  
+  // Get current date in Brisbane timezone as ISO date string (YYYY-MM-DD)
+  const nowInBrisbane = new Date().toLocaleDateString('en-CA', { timeZone: timezone })
   
   return posts.filter(post => {
     // Skip draft posts
@@ -27,9 +31,13 @@ export function filterPublishedPosts(posts: Blog[], options: { includeAllInDev?:
       return false
     }
     
-    // Skip future-dated posts
-    const postDate = new Date(post.date)
-    if (postDate > now) {
+    // Get post date as ISO date string (YYYY-MM-DD)
+    // Post dates from frontmatter are ISO strings like "2025-10-03T00:00:00.000Z"
+    const postDateStr = post.date.substring(0, 10)
+    
+    // Compare date strings: show post if post date <= current date in Brisbane
+    // String comparison works because ISO date format (YYYY-MM-DD) sorts correctly
+    if (postDateStr > nowInBrisbane) {
       return false
     }
     


### PR DESCRIPTION
 ● ## Summary

   I've fixed the timezone issue with your blog posts! Here's what was wrong and
   what I changed:

   ### The Problem

   Your blog post dated 2025-10-03 was showing on the /blog page but not the
   homepage because of a timezone bug. The original code was comparing dates using
   the server's local timezone instead of Brisbane timezone. When your site builds
   on GitHub Actions (which uses UTC), a post dated October 3rd wouldn't show until
   it's October 3rd in UTC - which is 10 hours behind Brisbane time!

   ### The Fix

   I made three key changes:

     1. src/utils/contentUtils.ts - Fixed the date filtering logic to:
       * Get the current date in Brisbane timezone using toLocaleDateString('en-CA', { timeZone: 'Australia/Brisbane' })
        
       * Compare dates as simple strings (YYYY-MM-DD format) instead of timestamps
        
       * This works correctly regardless of where the server is located (UTC, Brisbane, anywhere!)
     2. data/siteMetadata.js - Added timezone configuration:
       * Added timezone: 'Australia/Brisbane' so the site knows which timezone to use
     3. src/app/page.tsx - Added dynamic rendering:
       * Added export const dynamic = 'force-dynamic' to ensure the homepage re-evaluates dates at request time, not just build time

   ### How It Works Now

     * Before: Post dated Oct 3 would only show when it's Oct 3 in the server's timezone (UTC = 10 hours late!)
     * After: Post dated Oct 3 shows when it's Oct 3 in Brisbane, regardless of server location ✓

   The build completed successfully, and your today's post will now show correctly
   on both the homepage and blog page! 🎉