### PR TITLE
fix(blog): correct GitHub link formatting in Copilot article

### DIFF
--- a/data/blog/2025-10-03/taming-the-ai-my-paranoid-guide-to-running-copilot-cli-in-a-secure-docker-sandbox.mdx
+++ b/data/blog/2025-10-03/taming-the-ai-my-paranoid-guide-to-running-copilot-cli-in-a-secure-docker-sandbox.mdx
@@ -245,4 +245,4 @@ This setup gives me the confidence to fully embrace what the Copilot CLI has to 
 
 Ultimately, this approach allows me to balance power with pragmatism, giving me the freedom to use powerful tools like `--allow-all-tools` with a level of comfort I wouldn't have otherwise. I hope it helps you too\!
 
-You can find all the source code for this project on my GitHub repo at [https://github.com/GordonBeeming/copilot\_here](https://www.google.com/url?sa=E&source=gmail&q=https://github.com/GordonBeeming/copilot_here). Give it a try and let me know what you think\!
+You can find all the source code for this project on my GitHub repo at [https://github.com/GordonBeeming/copilot_here](https://github.com/GordonBeeming/copilot_here). Give it a try and let me know what you think\!


### PR DESCRIPTION
Fix the Markdown URL so the displayed and target GitHub link match.
This removes an accidental Google redirect URL and restores a direct
link to https://github.com/GordonBeeming/copilot_here so readers can
open the repository without being routed through a tracking/redirect
URL.