### PR TITLE
fix(security): expand detection of risky GitHub token scopes

### DIFF
--- a/data/blog/2025-10-03/taming-the-ai-my-paranoid-guide-to-running-copilot-cli-in-a-secure-docker-sandbox.mdx
+++ b/data/blog/2025-10-03/taming-the-ai-my-paranoid-guide-to-running-copilot-cli-in-a-secure-docker-sandbox.mdx
@@ -117,7 +117,7 @@ This version will always ask for your confirmation before executing commands in 
       fi
 
       # 2. Warn if the token has highly privileged scopes.
-      if gh auth status 2>/dev/null | grep "Token scopes:" | grep -q -E "'admin:org'|'admin:enterprise'"; then
+      if gh auth status 2>/dev/null | grep "Token scopes:" | grep -q -E "'(admin:|manage_|write:public_key|delete_repo|(write|delete)_packages)'"; then
         echo "⚠️  Warning: Your GitHub token has highly privileged scopes (e.g., admin:org, admin:enterprise)."
         printf "Are you sure you want to proceed with this token? [y/N]: "
         read confirmation
@@ -185,7 +185,7 @@ This is the "power user" option. It adds the `--allow-all-tools` flag to automat
       fi
 
       # 2. Warn if the token has highly privileged scopes.
-      if gh auth status 2>/dev/null | grep "Token scopes:" | grep -q -E "'admin:org'|'admin:enterprise'"; then
+      if gh auth status 2>/dev/null | grep "Token scopes:" | grep -q -E "'(admin:|manage_|write:public_key|delete_repo|(write|delete)_packages)'"; then
         echo "⚠️  Warning: Your GitHub token has highly privileged scopes (e.g., admin:org, admin:enterprise)."
         printf "Are you sure you want to proceed with this token? [y/N]: "
         read confirmation


### PR DESCRIPTION
Update the token-scope checks in the Copilot CLI sandbox setup to detect
a set of high-privilege scopes. Replace the previous checks
that only matched admin:org and admin:enterprise with a regex that also
flags scopes starting with admin:, manage_*, write:public_key, delete_repo,
and package write/delete scopes.

This tightens security warnings so users are prompted when using tokens
with potentially dangerous permissions, reducing the chance of running
the sandbox with overly privileged credentials.