### PR TITLE
feat(blog): add DevOps framing and expand on 10x mindset

### DIFF
--- a/data/blog/2025-09-17/the-10x-developer-mindset-isnt-about-you-its-about-your-ai.mdx
+++ b/data/blog/2025-09-17/the-10x-developer-mindset-isnt-about-you-its-about-your-ai.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The 10x Developer Mindset Isn't About You, It's About Your AI"
 date: 2025-09-17
-tags: ['AI', 'GitHub Spark', 'Gemini', 'Productivity', '10x Developer', 'Leadership']
+tags: ['AI', 'GitHub Spark', 'Gemini', 'Productivity', '10x Developer', 'Leadership', 'DevOps']
 draft: false
 summary: "For 10 years, I promised my wife a new portfolio website. I finally built it in 5 hours. The secret wasn't coding faster; it was realizing that the 10x developer mindset has nothing to do with me, and everything to do with how I lead my AI."
 ---
@@ -12,7 +12,20 @@ For about 10 years, I'd been promising my wife, [Tiani Beeming](https://tianibee
 
 Then, I finished it in about five hours. 🤯
 
-The secret wasn't a sudden burst of productivity or a new JavaScript framework. It was a fundamental change in my workflow. I stopped being the "doer" and became the "orchestrator," directing a team of AI agents to do the heavy lifting. This is the story of how that worked.
+The secret wasn't a sudden burst of productivity or a new JavaScript framework. It was a fundamental change in my workflow. I stopped being the "doer" and became the "orchestrator," directing a team of AI agents to do the heavy lifting. This project is what really solidified a new idea for me.
+
+## Redefining the "10x Developer"
+
+Let's be honest, the term "10x developer" can have a negative feeling around it. For a long time, I felt the same way. It often brings to mind a lone genius who just smashes out more code than everyone else. But recently, I've been thinking of it differently: as a **"10x Developer Mindset."**
+
+To me, this mindset has two core parts:
+
+1.  **Enabling Your Peers:** As an individual contributor, it's about uplifting the team around you. A 10x mindset means you're a force multiplier, enabling more "X" from your peers, not just yourself.
+2.  **Leveraging AI Effectively:** In isolation, especially with the rise of AI, it's about your proficiency in using the right AI tool for the right job, whether that's brainstorming, writing a new feature, or doing a massive refactor.
+
+This thinking borrows a lot from a DevOps and Growth Mindset. It's about collaboration, continuous improvement, and multiplying effectiveness across a system, not just focusing on individual output.
+
+This story is about how I put that second part, leveraging AI, into practice.
 
 ## The Frustration with "Prototype" AI
 

--- a/data/blog/2025-09-17/the-10x-developer-mindset-isnt-about-you-its-about-your-ai.mdx
+++ b/data/blog/2025-09-17/the-10x-developer-mindset-isnt-about-you-its-about-your-ai.mdx
@@ -23,7 +23,7 @@ To me, this mindset has two core parts:
 1.  **Enabling Your Peers:** As an individual contributor, it's about uplifting the team around you. A 10x mindset means you're a force multiplier, enabling more "X" from your peers, not just yourself.
 2.  **Leveraging AI Effectively:** In isolation, especially with the rise of AI, it's about your proficiency in using the right AI tool for the right job, whether that's brainstorming, writing a new feature, or doing a massive refactor.
 
-This thinking borrows a lot from a DevOps and Growth Mindset. It's about collaboration, continuous improvement, and multiplying effectiveness across a system, not just focusing on individual output.
+This thinking borrows a lot from DevOps principles and a Growth Mindset. It's about collaboration, continuous improvement, and multiplying effectiveness across a system, not just focusing on individual output.
 
 This story is about how I put that second part, leveraging AI, into practice.
 


### PR DESCRIPTION
Update the post "The 10x Developer Mindset Isn't About You, It's
About Your AI" to clarify and broaden the central argument.

- Add "DevOps" tag to better categorize the post's focus on
  collaboration and systems thinking.
- Expand the introduction to replace a closing sentence with a
  stronger transition and to introduce a new "Redefining the
  '10x Developer'" section.
- Define the "10x Developer Mindset" with two core parts:
  enabling peers (force-multiplying team impact) and leveraging AI
  effectively (choosing the right AI tools for tasks).
- Connect the mindset to DevOps and growth-mindset principles to
  emphasize collaboration, continuous improvement, and systemic
  multiplication of effectiveness.

These changes make the thesis more explicit and position the post
toward readers interested in team-level and DevOps-oriented
approaches to productivity with AI.