### PR TITLE
docs(blog): publish post about Tina CMS visual editing

### DIFF
--- a/data/blog/2025-10-13/adding-tina-cms-visual-editing-to-my-recipe-site.mdx
+++ b/data/blog/2025-10-13/adding-tina-cms-visual-editing-to-my-recipe-site.mdx
@@ -2,7 +2,7 @@
 title: 'Adding Tina CMS Visual Editing to My Recipe Site'
 date: '2025-10-13'
 tags: ['React', 'Tina CMS', 'Web Development', 'Debugging']
-draft: true
+draft: false
 summary: 'I had Tina CMS working for content management, but wanted that slick visual editing experience. Turns out adding the useTina hook broke my custom interactive components. Here''s the journey from "it should just work" to actually making it work.'
 ---
 


### PR DESCRIPTION
Mark the blog post "Adding Tina CMS Visual Editing to My Recipe Site"
as no longer a draft so it will appear on the site.

Explain why: the post documents integrating Tina CMS visual editing
and debugging the useTina hook that interfered with custom interactive
components, capturing the troubleshooting steps and final solution.