### PR TITLE
fix: correct Giscus repo from xylem-x to xylem

### DIFF
--- a/src/components/blog/Comments.tsx
+++ b/src/components/blog/Comments.tsx
@@ -33,7 +33,7 @@ export function Comments() {
           script.src = "https://giscus.app/client.js";
           script.setAttribute(
             "data-repo",
-            process.env.NEXT_PUBLIC_GISCUS_REPO ?? "gordonbeeming/xylem-x"
+            process.env.NEXT_PUBLIC_GISCUS_REPO ?? "gordonbeeming/xylem"
           );
           script.setAttribute(
             "data-repo-id",


### PR DESCRIPTION
The Giscus comments component was pointing to the old xylem-x repo
which no longer exists. Updated to gordonbeeming/xylem.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Co-authored-by: GitButler <gitbutler@gitbutler.com>