### PR TITLE
fix: set correct Giscus repo ID, category, and category ID

### DIFF
--- a/src/components/blog/Comments.tsx
+++ b/src/components/blog/Comments.tsx
@@ -37,15 +37,15 @@ export function Comments() {
           );
           script.setAttribute(
             "data-repo-id",
-            process.env.NEXT_PUBLIC_GISCUS_REPO_ID ?? ""
+            process.env.NEXT_PUBLIC_GISCUS_REPO_ID ?? "R_kgDOO0_MBQ"
           );
           script.setAttribute(
             "data-category",
-            process.env.NEXT_PUBLIC_GISCUS_CATEGORY ?? "Blog Comments"
+            process.env.NEXT_PUBLIC_GISCUS_CATEGORY ?? "Posts"
           );
           script.setAttribute(
             "data-category-id",
-            process.env.NEXT_PUBLIC_GISCUS_CATEGORY_ID ?? ""
+            process.env.NEXT_PUBLIC_GISCUS_CATEGORY_ID ?? "DIC_kwDOO0_MBc4Cq9Ps"
           );
           script.setAttribute("data-mapping", "pathname");
           script.setAttribute("data-strict", "0");


### PR DESCRIPTION
Giscus was failing with 404s because the repo ID and category ID
fallbacks were empty strings, and the category was set to
"Blog Comments" which doesn't exist. Updated to use the "Posts"
category which has all existing discussion threads.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Co-authored-by: GitButler <gitbutler@gitbutler.com>