### PR TITLE
fix: display original tag names instead of slugified versions

### DIFF
--- a/src/app/blog/BlogListClient.tsx
+++ b/src/app/blog/BlogListClient.tsx
@@ -20,6 +20,7 @@ interface PostData {
 interface BlogListClientProps {
   allPosts: PostData[];
   tagCounts: Record<string, number>;
+  tagDisplayNames: Record<string, string>;
   yearCounts: Record<string, number>;
 }
 
@@ -29,7 +30,7 @@ function slugifyTag(tag: string): string {
   return slug(tag).replace(/--+/g, "-");
 }
 
-function BlogListInner({ allPosts, tagCounts, yearCounts }: BlogListClientProps) {
+function BlogListInner({ allPosts, tagCounts, tagDisplayNames, yearCounts }: BlogListClientProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -209,7 +210,7 @@ function BlogListInner({ allPosts, tagCounts, yearCounts }: BlogListClientProps)
             }`}
             aria-pressed={selectedTag.toLowerCase() === tag.toLowerCase()}
           >
-            {tag} ({tagCounts[tag]})
+            {(tagDisplayNames[tag] ?? tag).replace(/-/g, " ")} ({tagCounts[tag]})
           </button>
         ))}
         {Object.keys(tagCounts).length > 20 && (
@@ -247,7 +248,7 @@ function BlogListInner({ allPosts, tagCounts, yearCounts }: BlogListClientProps)
           {filteredPosts.length === 0
             ? "No posts found"
             : `Showing ${startIndex + 1}–${Math.min(startIndex + POSTS_PER_PAGE, filteredPosts.length)} of ${filteredPosts.length} post${filteredPosts.length !== 1 ? "s" : ""}`}
-          {selectedTag && ` tagged "${selectedTag}"`}
+          {selectedTag && ` tagged "${tagDisplayNames[selectedTag] ?? selectedTag}"`}
           {selectedYear && ` from ${selectedYear}`}
           {searchQuery && ` matching "${searchQuery}"`}
         </p>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,5 +1,5 @@
 import { getPublishedPosts } from "@/lib/tina-helpers";
-import { getTagCounts, getYearCounts } from "@/lib/content";
+import { getTagCounts, getTagDisplayNames, getYearCounts } from "@/lib/content";
 import BlogListClient from "./BlogListClient";
 import type { Metadata } from "next";
 
@@ -22,7 +22,8 @@ export default function BlogPage() {
   }));
 
   const tagCounts = getTagCounts(published);
+  const tagDisplayNames = getTagDisplayNames(published);
   const yearCounts = getYearCounts(published);
 
-  return <BlogListClient allPosts={postsData} tagCounts={tagCounts} yearCounts={yearCounts} />;
+  return <BlogListClient allPosts={postsData} tagCounts={tagCounts} tagDisplayNames={tagDisplayNames} yearCounts={yearCounts} />;
 }

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { getPublishedPosts } from "@/lib/tina-helpers";
-import { getTagCounts } from "@/lib/content";
+import { getTagCounts, getTagDisplayNames } from "@/lib/content";
 import { BlogPostCard } from "@/components/blog/BlogPostCard";
 import { slug } from "github-slugger";
 import type { Metadata } from "next";
@@ -18,9 +18,12 @@ export async function generateStaticParams() {
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const { tag } = await props.params;
   const decodedTag = decodeURIComponent(tag);
+  const published = getPublishedPosts();
+  const displayNames = getTagDisplayNames(published);
+  const displayName = displayNames[decodedTag] ?? decodedTag;
   return {
-    title: `Posts tagged: ${decodedTag}`,
-    description: `Browse all blog posts tagged with "${decodedTag}" by Gordon Beeming.`,
+    title: `Posts tagged: ${displayName}`,
+    description: `Browse all blog posts tagged with "${displayName}" by Gordon Beeming.`,
   };
 }
 
@@ -29,6 +32,8 @@ export default async function TagFilteredPage(props: PageProps) {
   const decodedTag = decodeURIComponent(tag);
 
   const published = getPublishedPosts();
+  const displayNames = getTagDisplayNames(published);
+  const displayName = displayNames[decodedTag] ?? decodedTag;
   const filtered = published.filter((post) =>
     post.tags.some((t) => slug(t).replace(/--+/g, "-") === decodedTag)
   );
@@ -41,7 +46,7 @@ export default async function TagFilteredPage(props: PageProps) {
     <div className="mx-auto max-w-5xl px-6 py-12">
       <div className="mb-8 text-center">
         <h1 className="mb-2 text-4xl font-extrabold tracking-tight text-[var(--color-text-primary)]">
-          Posts tagged: {decodeURIComponent(tag)}
+          Posts tagged: {displayName}
         </h1>
         <p className="text-lg text-[var(--color-text-secondary)]">
           {filtered.length} post{filtered.length !== 1 ? "s" : ""}

--- a/src/app/tags/page.tsx
+++ b/src/app/tags/page.tsx
@@ -1,5 +1,5 @@
 import { getPublishedPosts } from "@/lib/tina-helpers";
-import { getTagCounts } from "@/lib/content";
+import { getTagCounts, getTagDisplayNames } from "@/lib/content";
 import { TagPill } from "@/components/ui/TagPill";
 import type { Metadata } from "next";
 
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
 export default function TagsPage() {
   const published = getPublishedPosts();
   const tagCounts = getTagCounts(published);
+  const tagDisplayNames = getTagDisplayNames(published);
 
   const sortedTags = Object.entries(tagCounts).sort(([, a], [, b]) => b - a);
   const totalTags = sortedTags.length;
@@ -28,7 +29,7 @@ export default function TagsPage() {
 
       <div className="flex flex-wrap justify-center gap-3">
         {sortedTags.map(([tag, count]) => (
-          <TagPill key={tag} tag={tag} count={count} />
+          <TagPill key={tag} tag={tagDisplayNames[tag] ?? tag} count={count} />
         ))}
       </div>
     </div>

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -48,6 +48,21 @@ export function getTagCounts(posts: { tags?: string[] | null }[]): Record<string
   return counts;
 }
 
+export function getTagDisplayNames(posts: { tags?: string[] | null }[]): Record<string, string> {
+  const names: Record<string, string> = {};
+  for (const post of posts) {
+    if (post.tags) {
+      for (const tag of post.tags) {
+        const s = slug(tag).replace(/--+/g, '-');
+        if (!names[s]) {
+          names[s] = tag;
+        }
+      }
+    }
+  }
+  return names;
+}
+
 export function getYearCounts(posts: { date: string }[]): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const post of posts) {


### PR DESCRIPTION
## Summary
- Tags were displayed as slugified strings (e.g. "AZURE-DEVOPS", "VSTS-TFS") because `tagCounts` keys are slugs
- Added `getTagDisplayNames()` to map slugs back to original display names (e.g. "Azure DevOps", "VSTS / TFS")
- Updated blog list page, tags index page, and individual tag pages to show original names
- URLs still use slugified versions for clean paths

## Test plan
- [ ] Visit `/blog` and verify tag pills show original names (e.g. "Azure DevOps" not "AZURE-DEVOPS")
- [ ] Visit `/tags` and verify all tags show original names
- [ ] Visit `/tags/azure-devops` and verify heading shows "Azure DevOps"
- [ ] Click tag pills on blog page and verify filtering still works
- [ ] Verify tag URLs still use slugified form

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [GitButler](https://gitbutler.com)