### PR TITLE
feat: blog post on Next.js + TinaCMS on GitHub Pages behind Cloudflare

### DIFF
--- a/content/blog/2026-03-22/nextjs-tinacms-on-github-pages-behind-cloudflare.mdx
+++ b/content/blog/2026-03-22/nextjs-tinacms-on-github-pages-behind-cloudflare.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Next.js + TinaCMS on GitHub Pages behind a Cloudflare Worker'
-date: 2026-03-22
+date: 2026-03-21
 tags: ['Next.js', 'TinaCMS', 'GitHub Pages', 'Cloudflare Workers', 'DevOps']
 draft: false
 summary: 'The gotchas I hit deploying a Next.js static export site with TinaCMS to GitHub Pages, proxied through a Cloudflare Worker — and how I fixed them.'

--- a/content/blog/2026-03-22/nextjs-tinacms-on-github-pages-behind-cloudflare.mdx
+++ b/content/blog/2026-03-22/nextjs-tinacms-on-github-pages-behind-cloudflare.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Next.js + TinaCMS on GitHub Pages behind a Cloudflare Worker'
-date: 2026-03-21
+date: 2026-03-22
 tags: ['Next.js', 'TinaCMS', 'GitHub Pages', 'Cloudflare Workers', 'DevOps']
 draft: false
 summary: 'The gotchas I hit deploying a Next.js static export site with TinaCMS to GitHub Pages, proxied through a Cloudflare Worker — and how I fixed them.'

--- a/content/blog/2026-03-22/nextjs-tinacms-on-github-pages-behind-cloudflare.mdx
+++ b/content/blog/2026-03-22/nextjs-tinacms-on-github-pages-behind-cloudflare.mdx
@@ -6,7 +6,7 @@ draft: false
 summary: 'The gotchas I hit deploying a Next.js static export site with TinaCMS to GitHub Pages, proxied through a Cloudflare Worker — and how I fixed them.'
 ---
 
-I recently moved this blog to a setup where Next.js builds a static export, TinaCMS provides a Git-backed CMS admin panel, GitHub Pages hosts the files for free, and a Cloudflare Worker sits in front handling the custom domain, security headers, and CSP.
+I recently moved this blog to a setup where Next.js builds a static export (hosted on GitHub Pages), TinaCMS provides a Git-backed CMS admin panel, and a Cloudflare Worker sits in front handling the custom domain, security headers, and CSP.
 
 It works great now, but getting here involved a few gotchas that weren't immediately obvious. This post documents the architecture and the fixes so you don't have to figure them out the hard way 🙃
 

--- a/content/blog/2026-03-22/nextjs-tinacms-on-github-pages-behind-cloudflare.mdx
+++ b/content/blog/2026-03-22/nextjs-tinacms-on-github-pages-behind-cloudflare.mdx
@@ -1,0 +1,211 @@
+---
+title: 'Next.js + TinaCMS on GitHub Pages behind a Cloudflare Worker'
+date: 2026-03-22
+tags: ['Next.js', 'TinaCMS', 'GitHub Pages', 'Cloudflare Workers', 'DevOps']
+draft: false
+summary: 'The gotchas I hit deploying a Next.js static export site with TinaCMS to GitHub Pages, proxied through a Cloudflare Worker — and how I fixed them.'
+---
+
+I recently moved this blog to a setup where Next.js builds a static export, TinaCMS provides a Git-backed CMS admin panel, GitHub Pages hosts the files for free, and a Cloudflare Worker sits in front handling the custom domain, security headers, and CSP.
+
+It works great now, but getting here involved a few gotchas that weren't immediately obvious. This post documents the architecture and the fixes so you don't have to figure them out the hard way 🙃
+
+## The Architecture
+
+The request flow looks like this:
+
+```text title="Request flow"
+Browser → gordonbeeming.com
+       → Cloudflare Worker (security headers, CSP, path rewriting)
+       → gordonbeeming.github.io/xylem/ (GitHub Pages static files)
+```
+
+The Cloudflare Worker does the heavy lifting at the edge:
+
+- **Path rewriting** — prepends the repo name (`/xylem`) to paths before forwarding to GitHub Pages
+- **Security headers** — adds `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, etc.
+- **CSP with nonce injection** — uses `HTMLRewriter` to inject nonces into `<script>` and `<style>` tags
+- **Redirects** — handles URL redirects that can't work at the static site level
+
+On the Next.js side, the config is straightforward:
+
+```typescript title="next.config.ts"
+const nextConfig: NextConfig = {
+  output: "export",
+  reactStrictMode: true,
+  images: {
+    formats: ["image/avif", "image/webp"],
+    unoptimized: true,
+  },
+};
+```
+
+And TinaCMS builds its admin panel into `public/admin/` as static files:
+
+```typescript title="tina/config.ts (build section)"
+build: {
+  outputFolder: "admin",
+  publicFolder: "public",
+},
+```
+
+Simple enough, right? Here's where it gets interesting.
+
+## Gotcha 1: Static Export Means No Server Features
+
+When you set `output: "export"`, Next.js generates a fully static site — no Node.js server, no API routes, no middleware, no rewrites, no redirects. If you have any API routes (like an OG image generator at `/api/og`), the build will fail:
+
+```text title="Build error"
+Error: export const dynamic = "force-static"/export const revalidate not configured
+on route "/api/og" with "output: export".
+```
+
+In CI, I handle this by removing API routes before building:
+
+```yaml title=".github/workflows/deploy.yml"
+- name: Prepare for static export
+  run: |
+    # Remove API routes (not compatible with static export)
+    rm -rf src/app/api
+
+- name: Build
+  run: pnpm build:tina
+```
+
+This means `pnpm dev` still works locally with API routes (it runs in dev mode, not export mode), but the production build knows to skip them.
+
+The bigger implication is that **redirects defined in `next.config.ts` don't work with static export**. If you have URL redirect rules (I had 146 of them for old blog post URLs), they need to move to the Cloudflare Worker.
+
+## Gotcha 2: GitHub Pages Redirect Leaks
+
+This one is subtle and took a while to track down.
+
+GitHub Pages likes to normalize URLs — for example, it redirects `/admin` to `/admin/` (trailing slash). It does this by returning a `301` response with a `Location` header. The problem? That `Location` header points to the **real** GitHub Pages URL:
+
+```text title="What GitHub Pages returns"
+HTTP/1.1 301 Moved Permanently
+Location: https://gordonbeeming.github.io/xylem/admin/
+```
+
+If your Cloudflare Worker just passes this response through to the browser, the user gets redirected from `gordonbeeming.com/admin` to `gordonbeeming.github.io/xylem/admin/` — completely bypassing your worker and exposing the underlying hosting.
+
+The fix is to **rewrite `Location` headers** in the worker before returning the response:
+
+```javascript title="Cloudflare Worker — Location header rewrite"
+const location = newHeaders.get("Location");
+if (location && domain === "gordonbeeming.com") {
+  const rewritten = location
+    .replace(
+      "https://gordonbeeming.github.io/xylem/",
+      "https://gordonbeeming.com/"
+    )
+    .replace(
+      "https://gordonbeeming.github.io/xylem",
+      "https://gordonbeeming.com"
+    );
+  if (rewritten !== location) {
+    newHeaders.set("Location", rewritten);
+  }
+}
+```
+
+Now the browser stays on `gordonbeeming.com` and never sees the `github.io` URL.
+
+## Gotcha 3: TinaCMS Admin on a Proxied Domain
+
+TinaCMS Cloud needs to know the URL of your site so the login flow works correctly. If the **Site URL** in your [TinaCMS Cloud dashboard](https://app.tina.io) doesn't match the URL in the browser, the login window won't close after authentication — it just hangs.
+
+For this setup, the Site URL must be set to your **custom domain** (`https://gordonbeeming.com`), not the GitHub Pages URL.
+
+There's also a `build.basePath` option in the TinaCMS config that you might think you need since the site lives at `/xylem/` on GitHub Pages. **Don't set it** when using a proxy worker. The worker already translates paths:
+
+- Browser requests `gordonbeeming.com/admin/assets/main.js`
+- Worker forwards to `gordonbeeming.github.io/xylem/admin/assets/main.js`
+
+If you set `basePath: "xylem"`, TinaCMS would generate asset paths like `/xylem/admin/assets/main.js`. Through the worker, that becomes `/xylem/xylem/admin/assets/main.js` — double prefix, broken assets.
+
+Without the `Location` header fix from Gotcha 2, visiting `/admin` redirects to `github.io` where TinaCMS shows "Failed loading TinaCMS assets" because everything is misaligned.
+
+## Gotcha 4: Redirects at the Edge
+
+Since Next.js static export can't handle redirects, they need to live in the Cloudflare Worker. I migrated all 146 redirect rules into a simple map:
+
+```javascript title="Cloudflare Worker — redirect map"
+const redirects = {
+  "/blog/old-post-slug": "/blog/2024-01-15/old-post-slug",
+  "/blog/tags/:slug*": "/tags/:slug*",
+  "/:path*.mdx": "/:path*",
+  // ... 143 more
+};
+```
+
+The worker checks the request path against this map before proxying to GitHub Pages. For wildcard patterns (like `/:path*.mdx`), I use a simple regex matcher:
+
+```javascript title="Cloudflare Worker — pattern matching"
+function matchRedirect(requestPath) {
+  for (const [pattern, destination] of Object.entries(redirects)) {
+    // Exact match
+    if (pattern === requestPath) return destination;
+
+    // Wildcard pattern match
+    if (pattern.includes(":")) {
+      const wildcardPlaceholder = "__WILDCARD__";
+      let regexSource = pattern.replace(/:[a-zA-Z]+\*/g, wildcardPlaceholder);
+      regexSource = regexSource.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      regexSource = regexSource.replace(
+        new RegExp(wildcardPlaceholder, "g"),
+        "(.*)"
+      );
+      const match = requestPath.match(new RegExp(`^${regexSource}$`));
+      if (match) {
+        let result = destination;
+        let i = 1;
+        const wildcards = destination.match(/:[a-zA-Z]+\*/g) || [];
+        for (const wc of wildcards) {
+          result = result.replace(wc, match[i] || "");
+          i++;
+        }
+        return result;
+      }
+    }
+  }
+  return null;
+}
+```
+
+One thing to watch out for: **preserve query strings** on redirects. If someone shares a link with UTM parameters, you don't want to drop them:
+
+```javascript title="Cloudflare Worker — preserving query strings"
+const redirectDest = matchRedirect(path);
+if (redirectDest) {
+  const search = url.search || "";
+  return new Response(null, {
+    status: 301,
+    headers: {
+      Location: `https://gordonbeeming.com${redirectDest}${search}`,
+    },
+  });
+}
+```
+
+## The Full Picture
+
+Here's a summary of the key configuration across the stack:
+
+| Layer | Config | Key Setting |
+|-------|--------|-------------|
+| Next.js | `next.config.ts` | `output: "export"`, `unoptimized: true` for images |
+| TinaCMS | `tina/config.ts` | `outputFolder: "admin"`, no `basePath` |
+| TinaCMS Cloud | Dashboard | Site URL = `https://yourdomain.com` |
+| GitHub Actions | `deploy.yml` | Remove API routes before build, deploy to Pages |
+| Cloudflare Worker | `src/index.js` | Path rewriting, Location header rewriting, redirects |
+
+## This Is a Living Post
+
+I'll update this post if I run into more gotchas with this setup. The beauty of a Git-backed CMS is that the post history is right there in the commit log 😄
+
+If you're running a similar setup and hit something I haven't covered, feel free to reach out — I'd love to add it here.
+
+**Repos:**
+- [xylem](https://github.com/GordonBeeming/xylem) — the Next.js site
+- [cloudflare-xylem-worker](https://github.com/GordonBeeming/cloudflare-xylem-worker) — the Cloudflare Worker

--- a/content/blog/2026-03-22/nextjs-tinacms-on-github-pages-behind-cloudflare.mdx
+++ b/content/blog/2026-03-22/nextjs-tinacms-on-github-pages-behind-cloudflare.mdx
@@ -74,6 +74,8 @@ In CI, I handle this by removing API routes before building:
 
 This means `pnpm dev` still works locally with API routes (it runs in dev mode, not export mode), but the production build knows to skip them.
 
+For anything the API routes were doing, you need a static alternative. In my case, the `/api/og` route generated Open Graph images on-the-fly using `next/og`. I replaced it with a build-time script (`scripts/generate-og-images.mjs`) that uses [satori](https://github.com/vercel/satori) and [@resvg/resvg-js](https://github.com/nickvdyck/resvg-js) to pre-render every OG image as a PNG into `public/og/`. Same visual output, but generated at build time instead of on each request.
+
 The bigger implication is that **redirects defined in `next.config.ts` don't work with static export**. If you have URL redirect rules (I had 146 of them for old blog post URLs), they need to move to the Cloudflare Worker.
 
 ## Gotcha 2: GitHub Pages Redirect Leaks

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
+const isDev = process.env.NODE_ENV === "development";
+
 const nextConfig: NextConfig = {
-  output: "export",
+  ...(!isDev ? { output: "export" } : {}),
   reactStrictMode: true,
   turbopack: {
     root: __dirname,

--- a/scripts/generate-og-images.mjs
+++ b/scripts/generate-og-images.mjs
@@ -29,9 +29,6 @@ function parsePost(filePath) {
   if (!data.title || !data.date) return null;
   if (data.draft === true) return null;
 
-  const date = data.date instanceof Date ? data.date : new Date(data.date);
-  if (date > new Date()) return null;
-
   const slug = path.relative(BLOG_DIR, filePath).replace(/\.mdx?$/, '');
   const rt = readingTime(content);
   return {

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -27,12 +27,7 @@ export function sortPosts<T extends { date: string }>(posts: T[]): T[] {
 export function filterPublishedPosts<T extends { draft?: boolean | null; date: string }>(
   posts: T[]
 ): T[] {
-  const now = new Date();
-  return posts.filter(post => {
-    if (post.draft) return false;
-    if (new Date(post.date) > now) return false;
-    return true;
-  });
+  return posts.filter(post => !post.draft);
 }
 
 export function getTagCounts(posts: { tags?: string[] | null }[]): Record<string, number> {

--- a/src/lib/tina-helpers.ts
+++ b/src/lib/tina-helpers.ts
@@ -101,12 +101,7 @@ export function getAllPosts(): PostMeta[] {
 }
 
 export function getPublishedPosts(): PostMeta[] {
-  const now = new Date();
-  return getAllPosts().filter((post) => {
-    if (post.draft) return false;
-    if (new Date(post.date) > now) return false;
-    return true;
-  });
+  return getAllPosts().filter((post) => !post.draft);
 }
 
 export function getPost(


### PR DESCRIPTION
## Summary
- New blog post documenting the architecture and gotchas of deploying Next.js static export + TinaCMS on GitHub Pages behind a Cloudflare Worker
- Fix: only apply `output: "export"` in production, not dev mode (dev was broken for dynamic routes)
- Fix: remove future-date filtering from `getPublishedPosts`, `filterPublishedPosts`, and OG image generation — only `draft` controls visibility now

## Test plan
- [ ] `pnpm dev` works and the new post renders at `/blog/2026-03-22/nextjs-tinacms-on-github-pages-behind-cloudflare`
- [ ] Post appears on home page
- [ ] `pnpm build` succeeds (with API routes removed, as CI does)

Solo with [Claude Code](https://claude.com/code) and [GitButler](https://gitbutler.com/) assistance.