### PR TITLE
fix: use custom domain URL in GitHub Actions deploy environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: https://gordonbeeming.com
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Show gordonbeeming.com instead of the GitHub Pages URL in the
deployment environment link on GitHub Actions.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Co-authored-by: GitButler <gitbutler@gitbutler.com>