### PR TITLE
feat: add feature flags system with SSW theme and edit-in-tina button

### DIFF
--- a/src/app/Main.tsx
+++ b/src/app/Main.tsx
@@ -20,9 +20,9 @@ interface MainProps {
 }
 
 const bookColors = [
-  "linear-gradient(135deg, #0063B2 0%, #004E8C 100%)",
-  "linear-gradient(135deg, #0075A3 0%, #005A7D 100%)",
-  "linear-gradient(135deg, #003A6B 0%, #002347 100%)",
+  "linear-gradient(135deg, var(--color-hero-gradient-start) 0%, var(--color-hero-gradient-mid) 100%)",
+  "linear-gradient(135deg, var(--color-brand-accent) 0%, var(--color-hero-gradient-mid) 100%)",
+  "linear-gradient(135deg, var(--color-hero-gradient-end) 0%, var(--color-hero-gradient-end) 100%)",
 ];
 
 type SocialKind =
@@ -50,13 +50,18 @@ export function Main({ posts, projects, books, siteConfig }: MainProps) {
   return (
     <>
       {/* Hero Section */}
-      <section className="hero-section relative overflow-hidden bg-[linear-gradient(135deg,#0063B2_0%,#004E8C_50%,#003A6B_100%)] px-6 pt-24 pb-32 text-center">
+      <section
+        className="hero-section relative overflow-hidden px-6 pt-24 pb-32 text-center"
+        style={{
+          background: "linear-gradient(135deg, var(--color-hero-gradient-start) 0%, var(--color-hero-gradient-mid) 50%, var(--color-hero-gradient-end) 100%)",
+        }}
+      >
         {/* Radial glow overlay */}
         <div
           className="pointer-events-none absolute inset-0"
           style={{
             background:
-              "radial-gradient(ellipse at 50% 0%, rgba(70,203,255,0.15) 0%, transparent 70%)",
+              "radial-gradient(ellipse at 50% 0%, var(--color-hero-radial) 0%, transparent 70%)",
           }}
         />
         {/* Dot pattern */}
@@ -76,7 +81,7 @@ export function Main({ posts, projects, books, siteConfig }: MainProps) {
               poster="/static/images/avatar.jpg"
               alt="Gordon Beeming"
               size={150}
-              className="border-2 border-[rgba(70,203,255,0.6)] shadow-xl"
+              className="border-2 border-[var(--color-hero-glow)] shadow-xl"
             />
           </div>
 
@@ -106,12 +111,18 @@ export function Main({ posts, projects, books, siteConfig }: MainProps) {
 
           {/* Terminal */}
           <div
-            className="mx-auto inline-block w-full max-w-[520px] rounded-lg border border-[rgba(70,203,255,0.15)] bg-black/25 px-6 py-4 text-left font-mono text-sm text-[#46CBFF]"
+            className="mx-auto inline-block w-full max-w-[520px] rounded-lg bg-black/25 px-6 py-4 text-left font-mono text-sm"
+            style={{
+              borderWidth: "1px",
+              borderStyle: "solid",
+              borderColor: "var(--color-hero-terminal-border)",
+              color: "var(--color-hero-terminal-text)",
+            }}
             aria-hidden="true"
           >
             <div>
               <span className="text-white/50">~/gordonbeeming $</span>{" "}
-              <span className="text-[#46CBFF]">cat status.txt</span>
+              <span style={{ color: "var(--color-hero-terminal-text)" }}>cat status.txt</span>
             </div>
             <div className="mt-1">
               <span className="hero-typing-text">
@@ -125,7 +136,7 @@ export function Main({ posts, projects, books, siteConfig }: MainProps) {
       {/* Latest Posts Section */}
       <section className="mx-auto max-w-7xl px-6 py-16">
         <AnimateOnScroll>
-          <h2 className="mb-2 border-l-[3px] border-l-[#0063B2] pl-4 text-[30px] font-extrabold leading-tight text-[var(--color-text-primary)]">
+          <h2 className="mb-2 border-l-[3px] border-l-[var(--color-brand-primary)] pl-4 text-[30px] font-extrabold leading-tight text-[var(--color-text-primary)]">
             Latest Posts
           </h2>
           <p className="mb-9 pl-[19px] text-[15px] text-[var(--color-text-secondary)]">
@@ -159,7 +170,7 @@ export function Main({ posts, projects, books, siteConfig }: MainProps) {
       <div className="bg-[var(--color-surface-tertiary)]">
         <section className="mx-auto max-w-7xl px-6 py-16">
           <AnimateOnScroll>
-            <h2 className="mb-2 border-l-[3px] border-l-[#0063B2] pl-4 text-[30px] font-extrabold leading-tight text-[var(--color-text-primary)]">
+            <h2 className="mb-2 border-l-[3px] border-l-[var(--color-brand-primary)] pl-4 text-[30px] font-extrabold leading-tight text-[var(--color-text-primary)]">
               Projects
             </h2>
             <p className="mb-9 pl-[19px] text-[15px] text-[var(--color-text-secondary)]">
@@ -248,7 +259,7 @@ export function Main({ posts, projects, books, siteConfig }: MainProps) {
       {/* Books Section */}
       <section className="mx-auto max-w-7xl px-6 py-16">
         <AnimateOnScroll>
-          <h2 className="mb-2 border-l-[3px] border-l-[#0063B2] pl-4 text-[30px] font-extrabold leading-tight text-[var(--color-text-primary)]">
+          <h2 className="mb-2 border-l-[3px] border-l-[var(--color-brand-primary)] pl-4 text-[30px] font-extrabold leading-tight text-[var(--color-text-primary)]">
             Books I&apos;ve Written
           </h2>
           <p className="mb-9 pl-[19px] text-[15px] text-[var(--color-text-secondary)]">

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -179,7 +179,7 @@ export default function AboutPage() {
 
         {/* Main content - Bio */}
         <div className="prose prose-lg max-w-none">
-          <h2 className="mb-6 border-l-[3px] border-l-[#0063B2] pl-4 text-[30px] font-extrabold leading-tight text-[var(--color-text-primary)]">
+          <h2 className="mb-6 border-l-[3px] border-l-[var(--color-brand-primary)] pl-4 text-[30px] font-extrabold leading-tight text-[var(--color-text-primary)]">
             About Me
           </h2>
           <div className="space-y-4 text-[var(--color-text-primary)]">

--- a/src/app/color-palette/page.tsx
+++ b/src/app/color-palette/page.tsx
@@ -104,7 +104,7 @@ export default function ColorPalettePage() {
       <div className="flex flex-col gap-10">
         {/* Header */}
         <div>
-          <h1 className="mb-2 border-l-[3px] border-l-[#0063B2] pl-4 text-[30px] font-extrabold leading-tight text-[var(--color-text-primary)] md:text-4xl">
+          <h1 className="mb-2 border-l-[3px] border-l-[var(--color-brand-primary)] pl-4 text-[30px] font-extrabold leading-tight text-[var(--color-text-primary)] md:text-4xl">
             My Color Palette
           </h1>
           <p className="mt-4 pl-[19px] text-lg text-[var(--color-text-secondary)]">

--- a/src/app/flags/page.tsx
+++ b/src/app/flags/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState, useCallback } from "react";
+import { FEATURE_FLAGS } from "@/lib/feature-flags";
+import { useFeatureFlags } from "@/components/FeatureFlagProvider";
+
+function FlagsContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { flags, setFlag, mounted } = useFeatureFlags();
+  const [copied, setCopied] = useState(false);
+
+  // Auto-set flags from URL params and redirect
+  useEffect(() => {
+    if (!mounted) return;
+
+    const flagKeys = FEATURE_FLAGS.map((f) => f.key);
+    const paramsToSet: Array<{ key: string; value: boolean }> = [];
+
+    for (const key of flagKeys) {
+      const paramValue = searchParams.get(key);
+      if (paramValue !== null) {
+        paramsToSet.push({ key, value: paramValue === "true" });
+      }
+    }
+
+    if (paramsToSet.length > 0) {
+      for (const { key, value } of paramsToSet) {
+        setFlag(key, value);
+      }
+      router.replace("/");
+    }
+  }, [mounted, searchParams, setFlag, router]);
+
+  const generateLink = useCallback(() => {
+    const enabledFlags = FEATURE_FLAGS.filter((f) => flags[f.key]);
+    if (enabledFlags.length === 0) return `${window.location.origin}/flags`;
+    const params = enabledFlags.map((f) => `${f.key}=true`).join("&");
+    return `${window.location.origin}/flags?${params}`;
+  }, [flags]);
+
+  const handleCopyLink = useCallback(async () => {
+    const link = generateLink();
+    await navigator.clipboard.writeText(link);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [generateLink]);
+
+  // Check if we have URL params that will trigger redirect
+  const hasUrlParams = FEATURE_FLAGS.some(
+    (f) => searchParams.get(f.key) !== null
+  );
+
+  if (!mounted || hasUrlParams) {
+    return (
+      <div className="mx-auto max-w-2xl px-6 py-16 text-center">
+        <p className="text-[var(--color-text-secondary)]">Loading flags...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-16">
+      <h1 className="mb-2 text-3xl font-extrabold tracking-tight text-[var(--color-text-primary)]">
+        Feature Flags
+      </h1>
+      <p className="mb-8 text-[var(--color-text-secondary)]">
+        Toggle experimental features. These settings are stored in your browser.
+      </p>
+
+      <div className="space-y-4">
+        {FEATURE_FLAGS.map((flag) => (
+          <div
+            key={flag.key}
+            className="flex items-center justify-between rounded-lg border border-[var(--color-border-default)] bg-[var(--color-surface-secondary)] p-4"
+          >
+            <div>
+              <h2 className="font-semibold text-[var(--color-text-primary)]">
+                {flag.key}
+              </h2>
+              <p className="text-sm text-[var(--color-text-tertiary)]">
+                {flag.description}
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={flags[flag.key] ?? flag.defaultValue}
+              onClick={() => setFlag(flag.key, !(flags[flag.key] ?? flag.defaultValue))}
+              className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-interactive-focus)] focus-visible:ring-offset-2 ${
+                flags[flag.key]
+                  ? "bg-[var(--color-interactive-default)]"
+                  : "bg-[var(--color-border-strong)]"
+              }`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ${
+                  flags[flag.key] ? "translate-x-5" : "translate-x-0"
+                }`}
+              />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* Copy Link */}
+      <div className="mt-8 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-surface-secondary)] p-4">
+        <h2 className="mb-2 font-semibold text-[var(--color-text-primary)]">
+          Share Configuration
+        </h2>
+        <p className="mb-3 text-sm text-[var(--color-text-tertiary)]">
+          Copy a link that applies your current flags when opened.
+        </p>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            readOnly
+            value={mounted ? generateLink() : ""}
+            className="flex-1 rounded-md border border-[var(--color-border-default)] bg-[var(--color-surface-primary)] px-3 py-2 text-sm text-[var(--color-text-primary)]"
+          />
+          <button
+            type="button"
+            onClick={handleCopyLink}
+            className="rounded-md bg-[var(--color-interactive-default)] px-4 py-2 text-sm font-medium text-[var(--color-text-on-primary)] transition-colors hover:bg-[var(--color-interactive-hover)]"
+          >
+            {copied ? "Copied!" : "Copy"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function FlagsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto max-w-2xl px-6 py-16 text-center">
+          <p className="text-[var(--color-text-secondary)]">Loading flags...</p>
+        </div>
+      }
+    >
+      <FlagsContent />
+    </Suspense>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import { ThemeProviders } from "@/components/ThemeProviders";
+import { FeatureFlagScript } from "@/components/FeatureFlagScript";
+import { FeatureFlagProvider } from "@/components/FeatureFlagProvider";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { GoogleAnalytics } from "@/components/GoogleAnalytics";
@@ -80,11 +82,14 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="bg-surface-primary text-text-primary antialiased">
+        <FeatureFlagScript />
         <GoogleAnalytics measurementId={GA_MEASUREMENT_ID} />
         <ThemeProviders>
-          <Header />
-          <main id="main-content">{children}</main>
-          <Footer />
+          <FeatureFlagProvider>
+            <Header />
+            <main id="main-content">{children}</main>
+            <Footer />
+          </FeatureFlagProvider>
         </ThemeProviders>
       </body>
     </html>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -21,7 +21,7 @@ export default async function ProjectsPage() {
     <div className="mx-auto max-w-7xl px-6 py-12 md:py-16">
       {/* Page hero */}
       <div className="mb-10">
-        <h1 className="mb-2 border-l-[3px] border-l-[#0063B2] pl-4 text-[30px] font-extrabold leading-tight text-[var(--color-text-primary)] md:text-4xl">
+        <h1 className="mb-2 border-l-[3px] border-l-[var(--color-brand-primary)] pl-4 text-[30px] font-extrabold leading-tight text-[var(--color-text-primary)] md:text-4xl">
           Projects
         </h1>
         <p className="pl-[19px] text-[15px] text-[var(--color-text-secondary)]">

--- a/src/components/FeatureFlagProvider.tsx
+++ b/src/components/FeatureFlagProvider.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import {
+  FEATURE_FLAGS,
+  getFlagDefault,
+  readFlagFromStorage,
+  writeFlagToStorage,
+} from "@/lib/feature-flags";
+
+interface FeatureFlagContextValue {
+  flags: Record<string, boolean>;
+  setFlag: (key: string, value: boolean) => void;
+  mounted: boolean;
+}
+
+const FeatureFlagContext = createContext<FeatureFlagContextValue>({
+  flags: {},
+  setFlag: () => {},
+  mounted: false,
+});
+
+function getInitialFlags(): Record<string, boolean> {
+  const flags: Record<string, boolean> = {};
+  for (const flag of FEATURE_FLAGS) {
+    flags[flag.key] = getFlagDefault(flag.key);
+  }
+  return flags;
+}
+
+function readAllFlags(): Record<string, boolean> {
+  const flags: Record<string, boolean> = {};
+  for (const flag of FEATURE_FLAGS) {
+    const stored = readFlagFromStorage(flag.key);
+    flags[flag.key] = stored ?? flag.defaultValue;
+  }
+  return flags;
+}
+
+function syncCssClasses(flags: Record<string, boolean>) {
+  const el = document.documentElement;
+  for (const flag of FEATURE_FLAGS) {
+    if (flag.cssClass) {
+      if (flags[flag.key]) {
+        el.classList.add(flag.cssClass);
+      } else {
+        el.classList.remove(flag.cssClass);
+      }
+    }
+  }
+}
+
+export function FeatureFlagProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [flags, setFlags] = useState<Record<string, boolean>>(getInitialFlags);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const stored = readAllFlags();
+    setFlags(stored);
+    syncCssClasses(stored);
+    setMounted(true);
+  }, []);
+
+  const setFlag = useCallback((key: string, value: boolean) => {
+    writeFlagToStorage(key, value);
+    setFlags((prev) => {
+      const next = { ...prev, [key]: value };
+      syncCssClasses(next);
+      return next;
+    });
+  }, []);
+
+  return (
+    <FeatureFlagContext.Provider value={{ flags, setFlag, mounted }}>
+      {children}
+    </FeatureFlagContext.Provider>
+  );
+}
+
+export function useFeatureFlags() {
+  return useContext(FeatureFlagContext);
+}

--- a/src/components/FeatureFlagScript.tsx
+++ b/src/components/FeatureFlagScript.tsx
@@ -1,0 +1,21 @@
+import { FEATURE_FLAGS, FEATURE_FLAG_STORAGE_PREFIX } from "@/lib/feature-flags";
+
+/**
+ * Inline script that reads feature flags from localStorage before React hydrates.
+ * This prevents flash of wrong theme for CSS-class-based flags (e.g., SSW theme).
+ */
+export function FeatureFlagScript() {
+  const cssFlags = FEATURE_FLAGS.filter((f) => f.cssClass);
+
+  if (cssFlags.length === 0) return null;
+
+  // Build a minimal inline script that checks localStorage and applies CSS classes
+  const script = `(function(){try{var d=document.documentElement;${cssFlags
+    .map(
+      (f) =>
+        `if(localStorage.getItem("${FEATURE_FLAG_STORAGE_PREFIX}${f.key}")==="true")d.classList.add("${f.cssClass}");`
+    )
+    .join("")}}catch(e){}})();`;
+
+  return <script dangerouslySetInnerHTML={{ __html: script }} />;
+}

--- a/src/components/blog/BlogPostCard.tsx
+++ b/src/components/blog/BlogPostCard.tsx
@@ -27,7 +27,7 @@ export function BlogPostCard({ post, headingLevel = 3 }: BlogPostCardProps) {
     <article>
       <Link
         href={`/blog/${post.slug}`}
-        className="block rounded-xl border-l-2 border-l-transparent bg-[var(--color-surface-secondary)] p-6 shadow-[var(--shadow-card)] transition-all duration-200 ease-[var(--ease-default)] hover:-translate-y-0.5 hover:border-l-[#0063B2] hover:shadow-[var(--shadow-card-hover)]"
+        className="block rounded-xl border-l-2 border-l-transparent bg-[var(--color-surface-secondary)] p-6 shadow-[var(--shadow-card)] transition-all duration-200 ease-[var(--ease-default)] hover:-translate-y-0.5 hover:border-l-[var(--color-brand-primary)] hover:shadow-[var(--shadow-card-hover)]"
       >
         <time
           dateTime={post.date}

--- a/src/components/blog/EditInTinaButton.tsx
+++ b/src/components/blog/EditInTinaButton.tsx
@@ -11,9 +11,8 @@ export function EditInTinaButton({ relativePath }: EditInTinaButtonProps) {
 
   if (!enabled) return null;
 
-  // TinaCMS admin URL: collection name + relative path with / encoded as ~2F, no extension
-  const tinaPath = relativePath.replace(/\.mdx$/, "").replace(/\//g, "~2F");
-  const editUrl = `/admin/index.html#/collections/post/${tinaPath}`;
+  const slug = relativePath.replace(/\.mdx$/, "");
+  const editUrl = `/admin/index.html#/~/blog/${slug}`;
 
   return (
     <a

--- a/src/components/blog/EditInTinaButton.tsx
+++ b/src/components/blog/EditInTinaButton.tsx
@@ -16,12 +16,13 @@ export function EditInTinaButton({ relativePath }: EditInTinaButtonProps) {
   return (
     <a
       href={editUrl}
-      className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface-secondary)] px-3 py-1.5 text-sm font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-tertiary)] hover:text-[var(--color-text-primary)]"
+      title="Edit in Tina"
+      className="inline-flex items-center justify-center text-[var(--color-text-tertiary)] transition-colors hover:text-[var(--color-brand-primary)]"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        width="14"
-        height="14"
+        width="16"
+        height="16"
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
@@ -33,7 +34,7 @@ export function EditInTinaButton({ relativePath }: EditInTinaButtonProps) {
         <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
         <path d="m15 5 4 4" />
       </svg>
-      Edit in Tina
+      <span className="sr-only">Edit in Tina</span>
     </a>
   );
 }

--- a/src/components/blog/EditInTinaButton.tsx
+++ b/src/components/blog/EditInTinaButton.tsx
@@ -11,7 +11,9 @@ export function EditInTinaButton({ relativePath }: EditInTinaButtonProps) {
 
   if (!enabled) return null;
 
-  const editUrl = `/admin#/~/${relativePath}`;
+  // TinaCMS admin URL: collection name + relative path with / encoded as ~2F, no extension
+  const tinaPath = relativePath.replace(/\.mdx$/, "").replace(/\//g, "~2F");
+  const editUrl = `/admin#/collections/post/${tinaPath}`;
 
   return (
     <a

--- a/src/components/blog/EditInTinaButton.tsx
+++ b/src/components/blog/EditInTinaButton.tsx
@@ -13,7 +13,7 @@ export function EditInTinaButton({ relativePath }: EditInTinaButtonProps) {
 
   // TinaCMS admin URL: collection name + relative path with / encoded as ~2F, no extension
   const tinaPath = relativePath.replace(/\.mdx$/, "").replace(/\//g, "~2F");
-  const editUrl = `/admin#/collections/post/${tinaPath}`;
+  const editUrl = `/admin/index.html#/collections/post/${tinaPath}`;
 
   return (
     <a

--- a/src/components/blog/EditInTinaButton.tsx
+++ b/src/components/blog/EditInTinaButton.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useFeatureFlag } from "@/hooks/useFeatureFlag";
+
+interface EditInTinaButtonProps {
+  relativePath: string;
+}
+
+export function EditInTinaButton({ relativePath }: EditInTinaButtonProps) {
+  const enabled = useFeatureFlag("edit-in-tina");
+
+  if (!enabled) return null;
+
+  const editUrl = `/admin#/~/${relativePath}`;
+
+  return (
+    <a
+      href={editUrl}
+      className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface-secondary)] px-3 py-1.5 text-sm font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-tertiary)] hover:text-[var(--color-text-primary)]"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+        <path d="m15 5 4 4" />
+      </svg>
+      Edit in Tina
+    </a>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -7,6 +7,7 @@ const navigationLinks = [
   { href: "/tags", label: "Tags" },
   { href: "/about", label: "About" },
   { href: "/color-palette", label: "Color Palette" },
+  { href: "/flags", label: "Flags" },
 ];
 
 const supportLinks = [

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -31,7 +31,7 @@ export function Footer() {
         <div className="mb-10 grid grid-cols-1 gap-8 md:grid-cols-[2fr_1fr_1fr] md:gap-12">
           {/* Brand */}
           <div>
-            <div className="mb-3 text-lg font-extrabold text-[#46CBFF]">
+            <div className="mb-3 text-lg font-extrabold text-[var(--color-brand-highlight)]">
               xylem | Gordon Beeming
             </div>
             <p className="max-w-xs text-sm leading-7 text-white/55">
@@ -51,7 +51,7 @@ export function Footer() {
                 <li key={link.href}>
                   <Link
                     href={link.href}
-                    className="text-sm text-white/55 transition-colors duration-200 hover:text-[#46CBFF]"
+                    className="text-sm text-white/55 transition-colors duration-200 hover:text-[var(--color-brand-highlight)]"
                   >
                     {link.label}
                   </Link>
@@ -72,7 +72,7 @@ export function Footer() {
                     href={link.href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-sm text-white/55 transition-colors duration-200 hover:text-[#46CBFF]"
+                    className="text-sm text-white/55 transition-colors duration-200 hover:text-[var(--color-brand-highlight)]"
                   >
                     {link.label}
                   </a>

--- a/src/components/social-icons/SocialIcon.tsx
+++ b/src/components/social-icons/SocialIcon.tsx
@@ -84,7 +84,7 @@ export function SocialIcon({ kind, href, size = 20 }: SocialIconProps) {
       target="_blank"
       rel="noopener noreferrer"
       aria-label={platformLabels[kind]}
-      className="inline-flex items-center justify-center text-white/35 transition-all duration-200 hover:text-[#46CBFF] hover:-translate-y-px"
+      className="inline-flex items-center justify-center text-white/35 transition-all duration-200 hover:text-[var(--color-brand-highlight)] hover:-translate-y-px"
     >
       <svg
         viewBox="0 0 24 24"

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -243,7 +243,7 @@ body {
 }
 
 @keyframes blink-border {
-  0%, 50% { border-color: #46CBFF; }
+  0%, 50% { border-color: var(--color-hero-terminal-text); }
   51%, 100% { border-color: transparent; }
 }
 

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -26,6 +26,16 @@
   --color-interactive-hover: #004E8C;
   --color-interactive-focus: #46CBFF;
 
+  /* Hero / accent */
+  --color-hero-gradient-start: #0063B2;
+  --color-hero-gradient-mid: #004E8C;
+  --color-hero-gradient-end: #003A6B;
+  --color-hero-radial: rgba(70, 203, 255, 0.15);
+  --color-hero-glow: rgba(70, 203, 255, 0.6);
+  --color-hero-glow-subtle: rgba(70, 203, 255, 0.15);
+  --color-hero-terminal-border: rgba(70, 203, 255, 0.15);
+  --color-hero-terminal-text: #46CBFF;
+
   /* Borders */
   --color-border-default: #E9ECEF;
   --color-border-subtle: #F0F1F3;
@@ -107,6 +117,15 @@
 
   --color-info: #CC4141;
 
+  --color-hero-gradient-start: #CC4141;
+  --color-hero-gradient-mid: #A83636;
+  --color-hero-gradient-end: #8B2D2D;
+  --color-hero-radial: rgba(232, 101, 101, 0.15);
+  --color-hero-glow: rgba(232, 101, 101, 0.6);
+  --color-hero-glow-subtle: rgba(232, 101, 101, 0.15);
+  --color-hero-terminal-border: rgba(232, 101, 101, 0.15);
+  --color-hero-terminal-text: #E86565;
+
   --shadow-glow: 0 0 20px rgba(204, 65, 65, 0.15);
   --shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(204, 65, 65, 0.08);
 }
@@ -119,6 +138,8 @@
   --color-interactive-default: #E86565;
   --color-interactive-hover: #F08080;
   --color-interactive-focus: #E86565;
+
+  --color-hero-terminal-text: #F08080;
 
   --shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(232, 101, 101, 0.1);
 }
@@ -194,18 +215,18 @@ body {
 
 @keyframes avatarGlow {
   0%, 100% {
-    box-shadow: 0 0 0 4px rgba(70,203,255,0.15), 0 0 20px rgba(70,203,255,0.1);
-    border-color: rgba(70,203,255,0.4);
+    box-shadow: 0 0 0 4px var(--color-hero-glow-subtle), 0 0 20px var(--color-hero-glow-subtle);
+    border-color: var(--color-hero-glow);
   }
   50% {
-    box-shadow: 0 0 0 6px rgba(70,203,255,0.25), 0 0 40px rgba(70,203,255,0.2);
-    border-color: rgba(70,203,255,0.8);
+    box-shadow: 0 0 0 6px var(--color-hero-glow), 0 0 40px var(--color-hero-glow-subtle);
+    border-color: var(--color-hero-glow);
   }
 }
 
 .hero-typing-text {
   display: inline-block;
-  border-right: 2px solid #46CBFF;
+  border-right: 2px solid var(--color-hero-terminal-text);
   animation: typing 2.5s steps(44, end) 1s forwards, blink-border 1s steps(1) infinite 3.5s;
   white-space: nowrap;
   overflow: hidden;

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -95,6 +95,34 @@
   --shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(70, 203, 255, 0.1);
 }
 
+/* SSW Theme - Light mode */
+.ssw-theme {
+  --color-brand-primary: #CC4141;
+  --color-brand-accent: #9E3232;
+  --color-brand-highlight: #E86565;
+
+  --color-interactive-default: #CC4141;
+  --color-interactive-hover: #A83636;
+  --color-interactive-focus: #E86565;
+
+  --color-info: #CC4141;
+
+  --shadow-glow: 0 0 20px rgba(204, 65, 65, 0.15);
+  --shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(204, 65, 65, 0.08);
+}
+
+/* SSW Theme - Dark mode */
+.ssw-theme.dark {
+  --color-brand-primary: #E86565;
+  --color-brand-accent: #CC4141;
+
+  --color-interactive-default: #E86565;
+  --color-interactive-hover: #F08080;
+  --color-interactive-focus: #E86565;
+
+  --shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(232, 101, 101, 0.1);
+}
+
 /* Base styles */
 body {
   background-color: var(--color-surface-primary);

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -26,16 +26,6 @@
   --color-interactive-hover: #004E8C;
   --color-interactive-focus: #46CBFF;
 
-  /* Hero / accent */
-  --color-hero-gradient-start: #0063B2;
-  --color-hero-gradient-mid: #004E8C;
-  --color-hero-gradient-end: #003A6B;
-  --color-hero-radial: rgba(70, 203, 255, 0.15);
-  --color-hero-glow: rgba(70, 203, 255, 0.6);
-  --color-hero-glow-subtle: rgba(70, 203, 255, 0.15);
-  --color-hero-terminal-border: rgba(70, 203, 255, 0.15);
-  --color-hero-terminal-text: #46CBFF;
-
   /* Borders */
   --color-border-default: #E9ECEF;
   --color-border-subtle: #F0F1F3;
@@ -76,6 +66,18 @@
   --font-heading: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
   --font-body: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, 'Cascadia Code', 'Fira Code', Menlo, monospace;
+}
+
+/* Hero / accent - outside @theme because rgba() values aren't valid theme tokens */
+:root {
+  --color-hero-gradient-start: #0063B2;
+  --color-hero-gradient-mid: #004E8C;
+  --color-hero-gradient-end: #003A6B;
+  --color-hero-radial: rgba(70, 203, 255, 0.15);
+  --color-hero-glow: rgba(70, 203, 255, 0.6);
+  --color-hero-glow-subtle: rgba(70, 203, 255, 0.15);
+  --color-hero-terminal-border: rgba(70, 203, 255, 0.15);
+  --color-hero-terminal-text: #46CBFF;
 }
 
 /* Dark mode overrides */

--- a/src/hooks/useFeatureFlag.ts
+++ b/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,10 @@
+"use client";
+
+import { useFeatureFlags } from "@/components/FeatureFlagProvider";
+import { getFlagDefault } from "@/lib/feature-flags";
+
+export function useFeatureFlag(key: string): boolean {
+  const { flags, mounted } = useFeatureFlags();
+  if (!mounted) return getFlagDefault(key);
+  return flags[key] ?? getFlagDefault(key);
+}

--- a/src/layouts/PostLayout.tsx
+++ b/src/layouts/PostLayout.tsx
@@ -59,6 +59,7 @@ export function PostLayout({
               &middot;
             </span>
             <span>{meta.readingTime.text}</span>
+            <EditInTinaButton relativePath={`${meta.slug}.mdx`} />
           </div>
 
           {/* Tags */}
@@ -69,11 +70,6 @@ export function PostLayout({
               ))}
             </div>
           )}
-
-          {/* Edit in Tina (feature-flagged) */}
-          <div className="mt-4">
-            <EditInTinaButton relativePath={`${meta.slug}.mdx`} />
-          </div>
         </header>
 
         {/* Article Body */}

--- a/src/layouts/PostLayout.tsx
+++ b/src/layouts/PostLayout.tsx
@@ -5,6 +5,7 @@ import { RelatedPosts } from "@/components/blog/RelatedPosts";
 import { Comments } from "@/components/blog/Comments";
 import { TagPill } from "@/components/ui/TagPill";
 import { formatDate } from "@/lib/content";
+import { EditInTinaButton } from "@/components/blog/EditInTinaButton";
 import type { PostMeta } from "@/lib/tina-helpers";
 
 interface PostLayoutProps {
@@ -68,6 +69,11 @@ export function PostLayout({
               ))}
             </div>
           )}
+
+          {/* Edit in Tina (feature-flagged) */}
+          <div className="mt-4">
+            <EditInTinaButton relativePath={`${meta.slug}.mdx`} />
+          </div>
         </header>
 
         {/* Article Body */}

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,44 @@
+export interface FeatureFlagDefinition {
+  key: string;
+  description: string;
+  defaultValue: boolean;
+  /** If true, the flag controls a CSS class on <html> that must be applied before hydration */
+  cssClass?: string;
+}
+
+export const FEATURE_FLAGS: FeatureFlagDefinition[] = [
+  {
+    key: "edit-in-tina",
+    description: "Show 'Edit in Tina' button on blog posts",
+    defaultValue: false,
+  },
+  {
+    key: "ssw-theme",
+    description: "Apply SSW branded color theme",
+    defaultValue: false,
+    cssClass: "ssw-theme",
+  },
+];
+
+export const FEATURE_FLAG_STORAGE_PREFIX = "ff:";
+
+export function getStorageKey(flagKey: string): string {
+  return `${FEATURE_FLAG_STORAGE_PREFIX}${flagKey}`;
+}
+
+export function readFlagFromStorage(flagKey: string): boolean | null {
+  if (typeof window === "undefined") return null;
+  const value = localStorage.getItem(getStorageKey(flagKey));
+  if (value === null) return null;
+  return value === "true";
+}
+
+export function writeFlagToStorage(flagKey: string, value: boolean): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(getStorageKey(flagKey), String(value));
+}
+
+export function getFlagDefault(flagKey: string): boolean {
+  const flag = FEATURE_FLAGS.find((f) => f.key === flagKey);
+  return flag?.defaultValue ?? false;
+}


### PR DESCRIPTION
## Summary

- Add a client-side feature flags system stored in localStorage, read before React hydrates to prevent theme flash
- Add `/flags` page with toggles, shareable URL (auto-sets flags and redirects to home), and copy-link button
- Add SSW branded theme (`ssw-theme` flag) that overrides all brand colors to SSW red palette, supporting both light and dark mode with WCAG AA compliance
- Add "Edit in Tina" pencil icon on blog posts (`edit-in-tina` flag) linking to TinaCMS admin editor
- Replace hardcoded blue hex values across hero, headings, cards, footer, and social icons with CSS custom properties for theme-ability
- Add "Flags" link in footer navigation

## Test plan

- [ ] Visit `/flags`, toggle SSW theme on/off, verify red brand colors apply without flash on page reload
- [ ] Toggle dark mode with SSW theme active, verify dark SSW colors
- [ ] Toggle `edit-in-tina`, visit a blog post, verify pencil icon appears in the meta line
- [ ] Click the pencil icon (with `pnpm dev:tina` running), verify it opens TinaCMS editor for that post
- [ ] Copy link from flags page, open in incognito, verify flags auto-set and redirect to home
- [ ] Verify default (no flags) site looks unchanged from before

Solo with [Claude Code](https://claude.ai/code) and [GitButler](https://gitbutler.com/) assistance

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Co-authored-by: GitButler <gitbutler@gitbutler.com>