### PR TITLE
fix: Use asymmetric scroll thresholds to prevent iPad nav bounce

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -27,10 +27,8 @@ export function Header() {
     <>
       <SkipLink />
       <header
-        className={`sticky top-0 z-50 border-b border-[var(--color-border-default)] bg-[var(--color-surface-secondary)] backdrop-blur-md transition-transform duration-300 ease-[var(--ease-default)] [backface-visibility:hidden] [will-change:transform] ${
-          isHidden
-            ? "[-webkit-transform:translate3d(0,-100%,0)] [transform:translate3d(0,-100%,0)]"
-            : "[-webkit-transform:translate3d(0,0,0)] [transform:translate3d(0,0,0)]"
+        className={`sticky top-0 z-50 border-b border-[var(--color-border-default)] bg-[var(--color-surface-secondary)] backdrop-blur-md transition-transform duration-300 ease-[var(--ease-default)] ${
+          isHidden ? "-translate-y-full" : "translate-y-0"
         }`}
       >
         <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6">

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -4,9 +4,15 @@ import { useState, useEffect, useRef } from "react";
 
 type ScrollDirection = "up" | "down" | null;
 
+const TOP_THRESHOLD = 64;
+const HIDE_THRESHOLD = 50;
+const SHOW_THRESHOLD = 10;
+
 export function useScrollDirection(threshold = 10): ScrollDirection {
   const [scrollDirection, setScrollDirection] = useState<ScrollDirection>(null);
   const lastScrollY = useRef(0);
+  const lastDirection = useRef<ScrollDirection>(null);
+  const accumulatedDiff = useRef(0);
   const ticking = useRef(false);
 
   useEffect(() => {
@@ -14,15 +20,39 @@ export function useScrollDirection(threshold = 10): ScrollDirection {
 
     function updateScrollDirection() {
       const currentScrollY = window.scrollY;
-      const diff = currentScrollY - lastScrollY.current;
 
-      if (Math.abs(diff) < threshold) {
+      // Always show nav when near the top of the page
+      if (currentScrollY < TOP_THRESHOLD) {
+        setScrollDirection("up");
+        lastScrollY.current = currentScrollY;
+        accumulatedDiff.current = 0;
+        lastDirection.current = "up";
         ticking.current = false;
         return;
       }
 
-      setScrollDirection(diff > 0 ? "down" : "up");
+      const diff = currentScrollY - lastScrollY.current;
+      const newDirection: ScrollDirection = diff > 0 ? "down" : "up";
+
+      // Accumulate scroll distance in the same direction, reset on reversal
+      if (newDirection === lastDirection.current) {
+        accumulatedDiff.current += Math.abs(diff);
+      } else {
+        accumulatedDiff.current = Math.abs(diff);
+        lastDirection.current = newDirection;
+      }
+
       lastScrollY.current = currentScrollY;
+
+      // Asymmetric thresholds: require more scroll to hide than to show
+      // This prevents momentum deceleration from hiding the nav after a flick up
+      const requiredThreshold =
+        newDirection === "down" ? HIDE_THRESHOLD : SHOW_THRESHOLD;
+
+      if (accumulatedDiff.current >= requiredThreshold) {
+        setScrollDirection(newDirection);
+      }
+
       ticking.current = false;
     }
 


### PR DESCRIPTION
## Summary

- Reverts header CSS back to simple `sticky` + `translateY` (the GPU compositing and fixed positioning attempts from #224 and #225 were not addressing the root cause)
- Fixes `useScrollDirection` hook with asymmetric thresholds: requires 50px of accumulated downward scroll to hide the nav, but only 10px upward to show it — this prevents iPad Safari's momentum deceleration from bouncing the nav away after a flick up
- Always shows the nav when near the top of the page (within 64px)

## Test plan

- [ ] On iPad Safari, scroll down — nav hides
- [ ] Slowly scroll up — nav reappears and stays
- [ ] Flick up quickly — nav reappears and stays (no bounce)
- [ ] Scroll to top — nav always visible
- [ ] Desktop browsers unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [GitButler](https://gitbutler.com)