### PR TITLE
fix: Add missing pages to sitemap for better Google indexing

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -54,6 +54,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.5,
     },
+    {
+      url: `${siteUrl}/years`,
+      lastModified: todayStr,
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
+      url: `${siteUrl}/color-palette`,
+      lastModified: todayStr,
+      changeFrequency: 'monthly',
+      priority: 0.3,
+    },
   ];
 
   // Blog posts
@@ -90,5 +102,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
     })
   );
 
-  return [...staticPages, ...blogEntries, ...tagEntries, ...yearEntries];
+  // Book pages
+  const books = getAllBooks();
+  const bookEntries: MetadataRoute.Sitemap = books.map((book) => ({
+    url: `${siteUrl}/books/${book.slug}`,
+    lastModified: todayStr,
+    changeFrequency: 'monthly' as const,
+    priority: 0.5,
+  }));
+
+  return [
+    ...staticPages,
+    ...blogEntries,
+    ...tagEntries,
+    ...yearEntries,
+    ...bookEntries,
+  ];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from 'next';
-import { getAllPosts, getSiteConfig } from '@/lib/tina-helpers';
+import { getAllPosts, getAllBooks, getSiteConfig } from '@/lib/tina-helpers';
 import {
   filterPublishedPosts,
   sortPosts,


### PR DESCRIPTION
## Summary
- Added `/years` index, `/color-palette`, and `/books/[slug]` pages to the sitemap
- These pages existed but weren't in the sitemap, causing Google Search Console to report "No referring sitemaps detected"
- All redirects in Cloudflare worker are already 301 (permanent), so the 407 "not indexed" pages in Search Console are expected old-URL redirects

## Test plan
- [ ] Build succeeds (`pnpm build`)
- [ ] Verify `/sitemap.xml` contains `/years`, `/color-palette`, and `/books/*` entries
- [ ] Check Google Search Console after deploy to confirm sitemap is picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)