### PR TITLE
feat: DinD blog posts and mermaid diagram support

### DIFF
--- a/content/blog/2026-04-09/how-copilot-here-brokers-docker-in-docker-safely.mdx
+++ b/content/blog/2026-04-09/how-copilot-here-brokers-docker-in-docker-safely.mdx
@@ -1,0 +1,194 @@
+---
+title: 'How copilot_here Brokers Docker-in-Docker Safely'
+date: 2026-04-09
+tags: ['copilot_here', 'Docker', 'Security', 'Architecture']
+draft: false
+summary: 'Why I built a brokered Docker socket instead of sharing the raw one, how the two-phase request inspection works, and what it honestly cannot protect you from.'
+---
+
+If you just want the feature overview, [check out the copilot_here site](https://copilot_here.gordonbeeming.com#docker-broker). If you want the setup steps, head to the [setup guide](/blog/2026-04-09/setting-up-docker-in-docker-in-copilot-here). This post is the longer story: why I built the brokered Docker socket, how the internals work, and where the boundaries are.
+
+## The problem
+
+AI coding agents inside a sandbox need Docker access. Testcontainers spins up a database for integration tests. A build pipeline calls `docker build`. A test harness starts a Redis sidecar. All of these need a working Docker socket.
+
+The naive approach is to bind-mount the host's `/var/run/docker.sock` into the container:
+
+```bash title="Terminal"
+# This works. It's also terrifying.
+docker run -v /var/run/docker.sock:/var/run/docker.sock myimage
+```
+
+That socket is the Docker daemon's control plane. Whatever can reach it can:
+
+- Pull and run any image, including ones with host filesystem mounts
+- Spawn privileged containers with full host kernel access
+- Bind-mount `/etc`, `/root`, or the Docker socket itself into a new container
+- Attach to running containers on the host
+- Effectively become root on the host machine
+
+For a human developer, this is a calculated risk. You trust yourself not to run `docker run --privileged -v /:/host alpine sh`. For an AI agent operating autonomously, that trust is harder to justify.
+
+## What a broker changes
+
+Instead of handing the container the real Docker socket, copilot_here starts a host-side broker process that creates its own socket. The container connects to the broker, the broker decides whether to forward the request to the real daemon.
+
+```mermaid title="Request flow"
+sequenceDiagram
+    participant C as Container
+    participant B as DockerSocketBroker (host)
+    participant D as Docker Daemon
+
+    C->>B: POST /containers/create
+    B->>B: Phase 1: endpoint check
+    B->>B: Phase 2: body inspection
+    B->>D: approved, forward request
+    D-->>B: response
+    B-->>C: forwarded response
+```
+
+The broker sits in the copilot_here host process (C#/.NET, AOT compiled). On Linux and macOS it listens on a Unix domain socket at `/tmp/copilot-broker-{sessionId}.sock`. On Windows it uses a TCP loopback port reached through `host.docker.internal`. Either way, the container sees a normal Docker socket at `/var/run/docker.sock`. It has no idea a broker is in the middle.
+
+## Phase 1: Endpoint whitelist
+
+Every Docker API call is an HTTP request — `GET /containers/json`, `POST /containers/create`, `DELETE /images/sha256:abc123`. The broker maintains an explicit allowlist of method + path pairs. Currently 65 endpoints are allowed by default:
+
+```json title="Subset of default-docker-broker-rules.json"
+{
+  "allowed_endpoints": [
+    { "method": "GET",    "path": "/_ping" },
+    { "method": "GET",    "path": "/containers/json" },
+    { "method": "POST",   "path": "/containers/create" },
+    { "method": "POST",   "path": "/containers/*/start" },
+    { "method": "POST",   "path": "/containers/*/stop" },
+    { "method": "DELETE", "path": "/containers/*" },
+    { "method": "GET",    "path": "/images/json" },
+    { "method": "POST",   "path": "/images/create" },
+    { "method": "GET",    "path": "/networks" },
+    { "method": "POST",   "path": "/networks/create" }
+  ]
+}
+```
+
+Path matching is segment-aware: `*` matches exactly one path segment, `**` matches zero or more. API version prefixes (like `/v1.43/`) are stripped before matching. Anything not in the list gets a 403. Default-deny.
+
+## Phase 2: Body inspection
+
+Endpoint filtering handles the "which API calls are allowed" question. Body inspection handles "what configuration is allowed inside those calls." It only runs on `POST /containers/create` — that's where the dangerous configuration lives.
+
+The inspector parses the JSON body and checks five things:
+
+### Image allowlist
+
+The most important check. The `allowed_images` list starts **empty**, meaning no sibling containers can be spawned at all until you explicitly add patterns. The safe default for an AI agent is "name every image you trust, deny everything else."
+
+```json title="Example configuration"
+{
+  "body_inspection": {
+    "allowed_images": [
+      "mcr.microsoft.com/mssql/server:*",
+      "postgres:*",
+      "testcontainers/ryuk:*",
+      "redis:7*"
+    ]
+  }
+}
+```
+
+Patterns use glob matching. `*` matches any sequence of characters including slashes and colons.
+
+### Privilege rejection
+
+Blocks `HostConfig.Privileged = true`. A privileged container has unrestricted access to the host kernel: device access, all capabilities, no seccomp filtering. Default: reject.
+
+### Host namespace rejection
+
+Blocks `NetworkMode`, `PidMode`, `IpcMode`, or `UsernsMode` set to `"host"`. Sharing the host's network, PID, IPC, or user namespace breaks container isolation. Default: reject.
+
+### Forbidden bind mounts
+
+Inspects `HostConfig.Binds` and blocks mounts targeting:
+
+- `/` (host root)
+- `/etc`, `/root`, `/var`, `/usr`, `/bin`, `/sbin`
+- `/proc`, `/sys`
+- `/var/run/docker.sock`, `/run/docker.sock`
+
+Subpath matching is included, so `/etc/passwd` is caught by the `/etc` rule. Default: reject.
+
+### Dangerous capabilities
+
+Blocks `CapAdd` entries from a deny list: `SYS_ADMIN`, `SYS_MODULE`, `SYS_PTRACE`, `SYS_RAWIO`, `SYS_BOOT`, `MAC_ADMIN`, `MAC_OVERRIDE`, `DAC_READ_SEARCH`, `NET_ADMIN`, `AUDIT_CONTROL`. These capabilities let a container escape its sandbox in various ways. Default: reject.
+
+Each of these checks can be individually toggled off via the config file if a specific workflow requires it.
+
+## Standard mode vs Airlock mode
+
+### Standard mode
+
+The simplest setup. The broker listens on a socket, the container mounts it, Docker calls go through the broker. The container can reach the internet normally — only Docker API calls are mediated.
+
+```mermaid title="Standard mode"
+graph LR
+    App["App container<br/>DOCKER_HOST=<br/>unix:///var/run/docker.sock"] --> Broker["Broker<br/>(host)"]
+    Broker --> Daemon["Docker<br/>Daemon"]
+    App -. "internet access:<br/>unrestricted" .-> Internet["External<br/>network"]
+```
+
+### Airlock mode
+
+When DinD is combined with Airlock, there's more going on. The app container sits on an internal-only network and cannot reach the outside world directly. A proxy container bridges the gap.
+
+```mermaid title="Airlock + DinD mode"
+graph LR
+    subgraph Airlock["airlock network (internal, no external access)"]
+        App["App container<br/>DOCKER_HOST=<br/>tcp://proxy:2375"] --> Proxy["Proxy container<br/>(dual-homed)<br/>socat bridge"]
+        Sibling["Sibling containers<br/>(auto-joined)"] -.-> App
+    end
+    Proxy --> Broker["Broker<br/>(host)"]
+    Broker --> Daemon["Docker<br/>Daemon"]
+```
+
+The proxy container runs a Rust HTTP/HTTPS proxy for regular traffic plus a `socat` bridge that forwards Docker API calls from port 2375 to the host broker. The app container's `DOCKER_HOST` points at `tcp://proxy:2375`.
+
+Here's the part that took the most thought: when the broker inspects a `POST /containers/create` request in airlock mode, it rewrites the `NetworkMode` field. Siblings that would normally land on the default bridge network get placed on the airlock network instead. This means:
+
+- Siblings are reachable from the app container via Docker DNS (e.g., `mssql:1433`)
+- Siblings are also network-isolated, meaning they can only reach the proxy, not the external network directly
+- The airlock's HTTP/HTTPS filtering still applies to their traffic
+
+Without this rewrite, Testcontainers would start a database on the bridge network and the airlocked app container couldn't talk to it.
+
+**Known limitation:** The airlock network is `internal: true`, which means the workload container can't reach host-mapped ports. Testcontainers and similar frameworks that connect to siblings via `host.docker.internal:<random-port>` will time out in airlock mode. This is tracked in [#101](https://github.com/GordonBeeming/copilot_here/issues/101). The workaround is to use standard mode (`--dind` without airlock) where the broker still enforces all Docker API rules, you just lose the HTTP proxy network isolation.
+
+## Design decisions
+
+**Why a userspace proxy instead of eBPF or seccomp?** Portability. The broker runs on Linux, macOS, and Windows. eBPF is Linux-only and seccomp can't inspect HTTP request bodies. A userspace proxy works everywhere and can parse JSON.
+
+**Why default-deny with an empty image allowlist?** Because "opt-in to specific risk" is fundamentally safer than "opt-out of specific risk." An AI agent that can spawn any image is an AI agent that can pull a purpose-built escape tool. By starting empty, users must make a conscious decision about which images to trust.
+
+**Why inspect bodies and not just endpoints?** Because `POST /containers/create` is a single endpoint that can produce wildly different security outcomes depending on the body. A container with `"Privileged": true` is a completely different threat than one without it. Endpoint filtering alone can't distinguish between the two.
+
+**Why hand-rolled HTTP framing instead of Kestrel?** The broker needs to handle Docker's HTTP Upgrade protocol for `exec` and `attach` (WebSocket-style bidirectional streaming). After the request line is approved, the broker splices raw TCP streams rather than parsing the full HTTP body. This handles content-length, chunked transfer, and upgrade hijacking without a full HTTP server.
+
+## Remaining attack surface
+
+The broker shrinks the attack surface. It does not eliminate it. Here's what's still exposed:
+
+**Exec into siblings.** `POST /containers/*/exec` is in the endpoint allowlist and has no body inspection. An agent could exec arbitrary commands in any running sibling container. If that sibling has access to something the agent doesn't (a mounted secret, a network connection), exec is the bridge.
+
+**Docker build.** `POST /build` is allowed. A Dockerfile's `RUN` commands execute on the host Docker daemon during the build. A malicious Dockerfile could exfiltrate data, install backdoors in the built image, or probe the host network during build.
+
+**Archive write.** `PUT /containers/*/archive` lets files be written into running containers. An agent could inject a script into a running sibling's filesystem and then exec it.
+
+**Tag trust.** Image allowlist patterns like `postgres:*` trust every tag published to that repository. If an upstream image is compromised and a malicious tag is pushed, it would pass the allowlist. Use specific version tags where possible (e.g., `postgres:16.2` instead of `postgres:*`).
+
+These vectors require the agent to be actively trying to escape rather than accidentally doing something dangerous. The broker catches the common accidental cases: a coding agent that runs `docker run --privileged` because it found that in a Stack Overflow answer, or one that tries to mount `/etc` because a build script asked for it.
+
+For maximum lockdown, combine the broker with Airlock mode. Network isolation means even if an agent compromises a sibling container, that container can't reach anything outside the airlock network without going through the proxy.
+
+## What's next
+
+The broker is marked as beta. Whether body inspection gets extended to other endpoints (like exec or build) depends on feedback from people actually using it. If you hit a case where the current scope doesn't work for you, [open an issue](https://github.com/GordonBeeming/copilot_here/issues).
+
+If you want to set it up, the [setup guide](/blog/2026-04-09/setting-up-docker-in-docker-in-copilot-here) walks through enabling the broker, configuring image allowlists, and tuning privilege controls per repo. Or check the [copilot_here site](https://copilot_here.gordonbeeming.com#docker-broker) for the quick overview.

--- a/content/blog/2026-04-09/how-copilot-here-brokers-docker-in-docker-safely.mdx
+++ b/content/blog/2026-04-09/how-copilot-here-brokers-docker-in-docker-safely.mdx
@@ -6,7 +6,7 @@ draft: false
 summary: 'Why I built a brokered Docker socket instead of sharing the raw one, how the two-phase request inspection works, and what it honestly cannot protect you from.'
 ---
 
-If you just want the feature overview, [check out the copilot_here site](https://copilot_here.gordonbeeming.com#docker-broker). If you want the setup steps, head to the [setup guide](/blog/2026-04-09/setting-up-docker-in-docker-in-copilot-here). This post is the longer story: why I built the brokered Docker socket, how the internals work, and where the boundaries are.
+If you just want the feature overview, [check out the copilot_here site](https://gordonbeeming.com/copilot_here/#docker-broker). If you want the setup steps, head to the [setup guide](/blog/2026-04-09/setting-up-docker-in-docker-in-copilot-here). This post is the longer story: why I built the brokered Docker socket, how the internals work, and where the boundaries are.
 
 ## The problem
 
@@ -191,4 +191,4 @@ For maximum lockdown, combine the broker with Airlock mode. Network isolation me
 
 The broker is marked as beta. Whether body inspection gets extended to other endpoints (like exec or build) depends on feedback from people actually using it. If you hit a case where the current scope doesn't work for you, [open an issue](https://github.com/GordonBeeming/copilot_here/issues).
 
-If you want to set it up, the [setup guide](/blog/2026-04-09/setting-up-docker-in-docker-in-copilot-here) walks through enabling the broker, configuring image allowlists, and tuning privilege controls per repo. Or check the [copilot_here site](https://copilot_here.gordonbeeming.com#docker-broker) for the quick overview.
+If you want to set it up, the [setup guide](/blog/2026-04-09/setting-up-docker-in-docker-in-copilot-here) walks through enabling the broker, configuring image allowlists, and tuning privilege controls per repo. Or check the [copilot_here site](https://gordonbeeming.com/copilot_here/#docker-broker) for the quick overview.

--- a/content/blog/2026-04-09/setting-up-docker-in-docker-in-copilot-here.mdx
+++ b/content/blog/2026-04-09/setting-up-docker-in-docker-in-copilot-here.mdx
@@ -1,0 +1,232 @@
+---
+title: 'Setting Up Docker-in-Docker in copilot_here'
+date: 2026-04-09
+tags: ['copilot_here', 'Docker', 'DevOps', 'Testcontainers']
+draft: false
+summary: 'Step-by-step guide to enabling the brokered Docker socket, configuring image allowlists, and tuning privilege controls per repo.'
+---
+
+This is the practical setup guide. If you want to understand how the broker works under the hood, read the [technical deep dive](/blog/2026-04-09/how-copilot-here-brokers-docker-in-docker-safely) first.
+
+## Enabling the broker
+
+Two ways to get Docker access inside your copilot_here sandbox:
+
+### One-shot flag
+
+Pass `--dind` to enable the broker for a single session:
+
+```bash title="Terminal"
+copilot_here --dind --dotnet -p "run the integration tests"
+```
+
+The broker starts, creates a socket, mounts it into the container, and tears it down when the session ends. Nothing is persisted.
+
+### Persistent config
+
+Enable the broker for a project so it activates on every run:
+
+```bash title="Terminal"
+copilot_here --enable-docker-broker
+```
+
+This creates `.copilot_here/docker-broker.json` in your project directory with default settings. From now on, every `copilot_here` run in this directory starts the broker automatically. No `--dind` flag needed.
+
+To disable it later:
+
+```bash title="Terminal"
+copilot_here --disable-docker-broker
+```
+
+## Adding allowed images
+
+By default, the image allowlist is empty. That means **no containers can be spawned** until you explicitly add patterns. You decide what the agent is allowed to pull and run.
+
+```bash title="Terminal"
+# Add specific images
+copilot_here --add-docker-broker-image 'mcr.microsoft.com/mssql/server:*'
+copilot_here --add-docker-broker-image 'postgres:16*'
+copilot_here --add-docker-broker-image 'testcontainers/ryuk:*'
+copilot_here --add-docker-broker-image 'redis:7*'
+```
+
+### Pattern syntax
+
+Patterns use glob matching where `*` matches any sequence of characters (including `/` and `:`):
+
+| Pattern | Matches | Doesn't match |
+|---------|---------|---------------|
+| `postgres:16*` | `postgres:16`, `postgres:16.2`, `postgres:16-alpine` | `postgres:15`, `postgres:latest` |
+| `mcr.microsoft.com/mssql/server:*` | Any tag of that image | Other registries |
+| `redis:*` | Any Redis tag | `bitnami/redis:latest` |
+
+Keep patterns as specific as possible. `postgres:16*` is better than `postgres:*` which is better than `*:*`. The broader the pattern, the weaker the allowlist.
+
+To remove a pattern:
+
+```bash title="Terminal"
+copilot_here --remove-docker-broker-image 'redis:7*'
+```
+
+## Privilege controls
+
+By default, the broker rejects containers that request privileged mode. Some test frameworks or Docker-in-Docker setups need it. You can opt in per-project:
+
+```bash title="Terminal"
+# Allow privileged containers (use with caution)
+copilot_here --allow-privileged-docker-broker
+
+# Revert to default (deny privileged)
+copilot_here --deny-privileged-docker-broker
+```
+
+There are also global variants that apply across all projects:
+
+```bash title="Terminal"
+copilot_here --allow-privileged-global-docker-broker
+copilot_here --deny-privileged-global-docker-broker
+```
+
+Local settings override global settings.
+
+The privilege toggle only controls `HostConfig.Privileged`. The broker has four other safety checks that remain active regardless:
+
+- **Host namespace rejection** — blocks `NetworkMode`, `PidMode`, `IpcMode`, `UsernsMode` set to `"host"`
+- **Forbidden bind mounts** — blocks mounts targeting `/etc`, `/root`, `/var`, `/usr`, `/bin`, `/sbin`, `/proc`, `/sys`, and the Docker socket
+- **Dangerous capabilities** — blocks `SYS_ADMIN`, `SYS_MODULE`, `SYS_PTRACE`, `NET_ADMIN`, and others
+- **Image allowlist** — still applies regardless of privilege settings
+
+## Config file deep dive
+
+The broker configuration is a JSON file. Here's a fully annotated example:
+
+```json title=".copilot_here/docker-broker.json"
+{
+  "enabled": true,
+  "inherit_default_rules": true,
+  "mode": "enforce",
+  "enable_logging": false,
+  "body_inspection": {
+    "reject_privileged": true,
+    "reject_host_namespaces": true,
+    "reject_forbidden_binds": true,
+    "reject_dangerous_capabilities": true,
+    "allowed_images": [
+      "mcr.microsoft.com/mssql/server:*",
+      "postgres:16*",
+      "testcontainers/ryuk:*"
+    ]
+  },
+  "allowed_endpoints": []
+}
+```
+
+### Field reference
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `enabled` | `false` | Whether the broker activates automatically (without `--dind`) |
+| `inherit_default_rules` | `true` | Merge with the 65 built-in endpoint rules. Set to `false` to use only your custom endpoints |
+| `mode` | `"enforce"` | `"enforce"` blocks disallowed requests. `"monitor"` logs but forwards everything |
+| `enable_logging` | `false` | Write decisions to `~/.copilot_here/logs/docker-broker.jsonl` |
+| `body_inspection.reject_privileged` | `true` | Block `Privileged: true` |
+| `body_inspection.reject_host_namespaces` | `true` | Block `NetworkMode/PidMode/IpcMode/UsernsMode: "host"` |
+| `body_inspection.reject_forbidden_binds` | `true` | Block mounts to sensitive host paths |
+| `body_inspection.reject_dangerous_capabilities` | `true` | Block dangerous Linux capabilities |
+| `body_inspection.allowed_images` | `[]` | Glob patterns for allowed container images |
+| `allowed_endpoints` | `[]` | Custom endpoint rules (merged with defaults if `inherit_default_rules` is true) |
+
+### Config resolution order
+
+1. **Local** — `.copilot_here/docker-broker.json` in the project directory
+2. **Global** — `~/.config/copilot_here/docker-broker.json`
+3. **Embedded defaults** — compiled into the binary (65 endpoint rules, all safety checks enabled, empty image list)
+
+Local overrides global, global overrides embedded. When `inherit_default_rules` is true, your custom endpoints merge with the defaults. You only need to add new ones or override existing ones.
+
+## Using with Airlock
+
+DinD and Airlock can work together. When combined, the setup changes:
+
+- The proxy container runs a `socat` bridge that forwards Docker API calls to the host broker
+- The app container's `DOCKER_HOST` points at `tcp://proxy:2375` instead of a Unix socket
+- Sibling containers spawned by the agent get their `NetworkMode` rewritten to join the airlock network
+- Siblings are reachable via Docker DNS and network-isolated. They can't bypass the proxy
+
+If you're already using Airlock, adding `--dind` (or enabling the broker in config) is all you need. The compose template handles the rest automatically.
+
+**Known limitation:** Testcontainers and similar frameworks that connect to siblings via host-mapped ports (e.g., `host.docker.internal:32768`) won't work in airlock mode yet ([#101](https://github.com/GordonBeeming/copilot_here/issues/101)). The airlock's `internal: true` network blocks those connections. Use `--dind` without airlock as a workaround. The broker still enforces all API rules, you just lose the HTTP proxy network isolation.
+
+## Viewing and editing rules
+
+```bash title="Terminal"
+# See the effective merged rules (local + global + defaults)
+copilot_here --show-docker-broker-rules
+
+# Open the local config file in $EDITOR
+copilot_here --edit-docker-broker-rules
+```
+
+`--show-docker-broker-rules` outputs the fully resolved configuration after merging all layers, so you can verify what's actually active.
+
+## Common patterns
+
+### Testcontainers with .NET
+
+Testcontainers needs Ryuk (its resource reaper) plus whatever database images your tests use. Set up once with persistent config, then your normal interactive sessions have Docker access:
+
+```bash title="One-time setup"
+copilot_here --enable-docker-broker
+copilot_here --add-docker-broker-image 'testcontainers/ryuk:*'
+copilot_here --add-docker-broker-image 'mcr.microsoft.com/mssql/server:2022*'
+```
+
+```bash title="Then just use copilot_here normally"
+copilot_here --dotnet
+```
+
+The agent can run your integration tests during the conversation and Testcontainers will work. You can also verify the setup with a one-shot: `copilot_here --dind --dotnet -p "run the integration tests"`.
+
+### Postgres for integration tests
+
+If you don't want persistent config, use `--dind` for a one-off session:
+
+```bash title="Terminal"
+copilot_here --add-docker-broker-image 'postgres:16*'
+copilot_here --dind --dotnet
+```
+
+### Multiple services
+
+Some test suites need several containers. Add each image you need:
+
+```bash title="Terminal"
+copilot_here --add-docker-broker-image 'postgres:16*'
+copilot_here --add-docker-broker-image 'redis:7*'
+copilot_here --add-docker-broker-image 'rabbitmq:3*'
+copilot_here --add-docker-broker-image 'testcontainers/ryuk:*'
+```
+
+### Monitor mode
+
+If you want to see what Docker calls the agent makes before enforcing rules:
+
+```json title=".copilot_here/docker-broker.json"
+{
+  "enabled": true,
+  "mode": "monitor",
+  "enable_logging": true,
+  "inherit_default_rules": true,
+  "body_inspection": {
+    "allowed_images": ["*"]
+  }
+}
+```
+
+This logs every decision to `~/.copilot_here/logs/docker-broker.jsonl` but forwards all requests. Good for understanding what your test suite actually needs before locking it down.
+
+## Wrapping up
+
+The brokered Docker socket is currently in beta. The defaults are conservative: empty image list, all safety checks on, enforce mode. Start with the minimum set of images your workflow needs and expand from there.
+
+For the technical details on how the broker intercepts and inspects requests, read the [deep dive post](/blog/2026-04-09/how-copilot-here-brokers-docker-in-docker-safely). For the quick overview, check the [copilot_here site](https://copilot_here.gordonbeeming.com#docker-broker).

--- a/content/blog/2026-04-09/setting-up-docker-in-docker-in-copilot-here.mdx
+++ b/content/blog/2026-04-09/setting-up-docker-in-docker-in-copilot-here.mdx
@@ -229,4 +229,4 @@ This logs every decision to `~/.copilot_here/logs/docker-broker.jsonl` but forwa
 
 The brokered Docker socket is currently in beta. The defaults are conservative: empty image list, all safety checks on, enforce mode. Start with the minimum set of images your workflow needs and expand from there.
 
-For the technical details on how the broker intercepts and inspects requests, read the [deep dive post](/blog/2026-04-09/how-copilot-here-brokers-docker-in-docker-safely). For the quick overview, check the [copilot_here site](https://copilot_here.gordonbeeming.com#docker-broker).
+For the technical details on how the broker intercepts and inspects requests, read the [deep dive post](/blog/2026-04-09/how-copilot-here-brokers-docker-in-docker-safely). For the quick overview, check the [copilot_here site](https://gordonbeeming.com/copilot_here/#docker-broker).

--- a/src/app/blog/[...slug]/page.tsx
+++ b/src/app/blog/[...slug]/page.tsx
@@ -17,6 +17,7 @@ import { Figure } from "@/components/prose/Figure";
 import { YouTubeEmbed } from "@/components/prose/YouTubeEmbed";
 import { TableWrapper } from "@/components/prose/TableWrapper";
 import { CodeBlock } from "@/components/prose/CodeBlock";
+import { MermaidDiagram } from "@/components/prose/MermaidDiagram";
 // rehype-code-meta no longer needed — shiki transformers handle meta
 import type { Metadata } from "next";
 
@@ -106,6 +107,11 @@ const mdxComponents = {
       return "";
     }
     const code = extractText(child?.props?.children).replace(/\n$/, "");
+
+    // Render mermaid code blocks as interactive diagrams instead of syntax-highlighted code
+    if (language === "mermaid") {
+      return <MermaidDiagram chart={code} title={filename} />;
+    }
 
     return (
       <CodeBlock code={code} language={language} filename={filename}>

--- a/src/components/prose/MermaidDiagram.tsx
+++ b/src/components/prose/MermaidDiagram.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTheme } from "next-themes";
+import mermaid from "mermaid";
+
+interface MermaidDiagramProps {
+  chart: string;
+  title?: string;
+}
+
+// Unique ID counter to avoid collisions when multiple diagrams exist on one page
+let idCounter = 0;
+
+export function MermaidDiagram({ chart, title }: MermaidDiagramProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [svg, setSvg] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  const { resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    const id = `mermaid-${++idCounter}`;
+    const isDark = resolvedTheme === "dark";
+
+    // Use the 'base' theme so we can override variables to match the blog's brand
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: "base",
+      themeVariables: isDark
+        ? {
+            // Dark mode - matches blog's dark palette
+            primaryColor: "#334155",
+            primaryTextColor: "#E0E0E0",
+            primaryBorderColor: "#46CBFF",
+            lineColor: "#46CBFF",
+            secondaryColor: "#2C2C2C",
+            tertiaryColor: "#242424",
+            textColor: "#E0E0E0",
+            mainBkg: "#334155",
+            nodeBorder: "#46CBFF",
+            actorBkg: "#334155",
+            actorBorder: "#46CBFF",
+            actorTextColor: "#E0E0E0",
+            actorLineColor: "#9CA3AF",
+            signalColor: "#E0E0E0",
+            signalTextColor: "#E0E0E0",
+            labelBoxBkgColor: "#2C2C2C",
+            labelBoxBorderColor: "#46CBFF",
+            labelTextColor: "#E0E0E0",
+            loopTextColor: "#E0E0E0",
+            noteBkgColor: "#2C2C2C",
+            noteTextColor: "#E0E0E0",
+            noteBorderColor: "#46CBFF",
+            activationBkgColor: "#334155",
+            activationBorderColor: "#46CBFF",
+            sequenceNumberColor: "#E0E0E0",
+          }
+        : {
+            // Light mode - matches blog's light palette
+            primaryColor: "#E9ECEF",
+            primaryTextColor: "#1A1A1A",
+            primaryBorderColor: "#0063B2",
+            lineColor: "#0063B2",
+            secondaryColor: "#F8F9FA",
+            tertiaryColor: "#FFFFFF",
+            textColor: "#1A1A1A",
+            mainBkg: "#E9ECEF",
+            nodeBorder: "#0063B2",
+            actorBkg: "#E9ECEF",
+            actorBorder: "#0063B2",
+            actorTextColor: "#1A1A1A",
+            actorLineColor: "#6B7280",
+            signalColor: "#1A1A1A",
+            signalTextColor: "#1A1A1A",
+            labelBoxBkgColor: "#FFFFFF",
+            labelBoxBorderColor: "#0063B2",
+            labelTextColor: "#1A1A1A",
+            loopTextColor: "#1A1A1A",
+            noteBkgColor: "#FFFFFF",
+            noteTextColor: "#1A1A1A",
+            noteBorderColor: "#0063B2",
+            activationBkgColor: "#E9ECEF",
+            activationBorderColor: "#0063B2",
+            sequenceNumberColor: "#FFFFFF",
+          },
+      flowchart: { useMaxWidth: true },
+      sequence: { useMaxWidth: true },
+    });
+
+    mermaid
+      .render(id, chart.trim())
+      .then(({ svg: renderedSvg }) => {
+        setSvg(renderedSvg);
+        setError("");
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+      });
+  }, [chart, resolvedTheme]);
+
+  if (error) {
+    return (
+      <div className="my-6 rounded-xl border border-red-300 bg-red-50 p-4 text-sm text-red-700 dark:border-red-700 dark:bg-red-950 dark:text-red-300">
+        <p className="font-medium">Mermaid diagram error</p>
+        <pre className="mt-2 whitespace-pre-wrap text-xs">{error}</pre>
+      </div>
+    );
+  }
+
+  if (!svg) {
+    return (
+      <div className="my-6 flex h-32 items-center justify-center rounded-xl border border-[var(--color-border-default)] bg-[var(--color-surface-secondary)]">
+        <span className="text-sm text-[var(--color-text-secondary)]">
+          Loading diagram...
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-6 overflow-hidden rounded-xl border border-[var(--color-border-default)]">
+      {title && (
+        <div className="border-b border-[var(--color-border-default)] bg-[var(--color-surface-tertiary)] px-4 py-2">
+          <span
+            className="text-[13px] font-medium text-[var(--color-text-secondary)]"
+            style={{ fontFamily: "var(--font-mono)" }}
+          >
+            {title}
+          </span>
+        </div>
+      )}
+      <div
+        ref={containerRef}
+        className="overflow-x-auto bg-[var(--color-surface-secondary)] p-4 [&_svg]:mx-auto"
+        dangerouslySetInnerHTML={{ __html: svg }}
+      />
+    </div>
+  );
+}

--- a/src/components/prose/MermaidDiagram.tsx
+++ b/src/components/prose/MermaidDiagram.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { useTheme } from "next-themes";
 import mermaid from "mermaid";
 
@@ -12,92 +12,119 @@ interface MermaidDiagramProps {
 // Unique ID counter to avoid collisions when multiple diagrams exist on one page
 let idCounter = 0;
 
+// Track the last theme we initialized mermaid with so we only reinitialize
+// when the theme actually changes, not on every component mount.
+let lastInitializedTheme: string | null = null;
+
+function initMermaidForTheme(isDark: boolean) {
+  const themeKey = isDark ? "dark" : "light";
+  if (lastInitializedTheme === themeKey) return;
+
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: "base",
+    themeVariables: isDark
+      ? {
+          primaryColor: "#334155",
+          primaryTextColor: "#E0E0E0",
+          primaryBorderColor: "#46CBFF",
+          lineColor: "#46CBFF",
+          secondaryColor: "#2C2C2C",
+          tertiaryColor: "#242424",
+          textColor: "#E0E0E0",
+          mainBkg: "#334155",
+          nodeBorder: "#46CBFF",
+          actorBkg: "#334155",
+          actorBorder: "#46CBFF",
+          actorTextColor: "#E0E0E0",
+          actorLineColor: "#9CA3AF",
+          signalColor: "#E0E0E0",
+          signalTextColor: "#E0E0E0",
+          labelBoxBkgColor: "#2C2C2C",
+          labelBoxBorderColor: "#46CBFF",
+          labelTextColor: "#E0E0E0",
+          loopTextColor: "#E0E0E0",
+          noteBkgColor: "#2C2C2C",
+          noteTextColor: "#E0E0E0",
+          noteBorderColor: "#46CBFF",
+          activationBkgColor: "#334155",
+          activationBorderColor: "#46CBFF",
+          sequenceNumberColor: "#E0E0E0",
+        }
+      : {
+          primaryColor: "#E9ECEF",
+          primaryTextColor: "#1A1A1A",
+          primaryBorderColor: "#0063B2",
+          lineColor: "#0063B2",
+          secondaryColor: "#F8F9FA",
+          tertiaryColor: "#FFFFFF",
+          textColor: "#1A1A1A",
+          mainBkg: "#E9ECEF",
+          nodeBorder: "#0063B2",
+          actorBkg: "#E9ECEF",
+          actorBorder: "#0063B2",
+          actorTextColor: "#1A1A1A",
+          actorLineColor: "#6B7280",
+          signalColor: "#1A1A1A",
+          signalTextColor: "#1A1A1A",
+          labelBoxBkgColor: "#FFFFFF",
+          labelBoxBorderColor: "#0063B2",
+          labelTextColor: "#1A1A1A",
+          loopTextColor: "#1A1A1A",
+          noteBkgColor: "#FFFFFF",
+          noteTextColor: "#1A1A1A",
+          noteBorderColor: "#0063B2",
+          activationBkgColor: "#E9ECEF",
+          activationBorderColor: "#0063B2",
+          sequenceNumberColor: "#FFFFFF",
+        },
+    flowchart: { useMaxWidth: true },
+    sequence: { useMaxWidth: true },
+  });
+
+  lastInitializedTheme = themeKey;
+}
+
 export function MermaidDiagram({ chart, title }: MermaidDiagramProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [svg, setSvg] = useState<string>("");
   const [error, setError] = useState<string>("");
+  // Stores bindFunctions so we can call it after the SVG is in the DOM
+  const bindFunctionsRef = useRef<((element: Element) => void) | null>(null);
   const { resolvedTheme } = useTheme();
 
-  useEffect(() => {
+  const renderDiagram = useCallback(async (signal: { cancelled: boolean }) => {
     const id = `mermaid-${++idCounter}`;
     const isDark = resolvedTheme === "dark";
+    initMermaidForTheme(isDark);
 
-    // Use the 'base' theme so we can override variables to match the blog's brand
-    mermaid.initialize({
-      startOnLoad: false,
-      theme: "base",
-      themeVariables: isDark
-        ? {
-            // Dark mode - matches blog's dark palette
-            primaryColor: "#334155",
-            primaryTextColor: "#E0E0E0",
-            primaryBorderColor: "#46CBFF",
-            lineColor: "#46CBFF",
-            secondaryColor: "#2C2C2C",
-            tertiaryColor: "#242424",
-            textColor: "#E0E0E0",
-            mainBkg: "#334155",
-            nodeBorder: "#46CBFF",
-            actorBkg: "#334155",
-            actorBorder: "#46CBFF",
-            actorTextColor: "#E0E0E0",
-            actorLineColor: "#9CA3AF",
-            signalColor: "#E0E0E0",
-            signalTextColor: "#E0E0E0",
-            labelBoxBkgColor: "#2C2C2C",
-            labelBoxBorderColor: "#46CBFF",
-            labelTextColor: "#E0E0E0",
-            loopTextColor: "#E0E0E0",
-            noteBkgColor: "#2C2C2C",
-            noteTextColor: "#E0E0E0",
-            noteBorderColor: "#46CBFF",
-            activationBkgColor: "#334155",
-            activationBorderColor: "#46CBFF",
-            sequenceNumberColor: "#E0E0E0",
-          }
-        : {
-            // Light mode - matches blog's light palette
-            primaryColor: "#E9ECEF",
-            primaryTextColor: "#1A1A1A",
-            primaryBorderColor: "#0063B2",
-            lineColor: "#0063B2",
-            secondaryColor: "#F8F9FA",
-            tertiaryColor: "#FFFFFF",
-            textColor: "#1A1A1A",
-            mainBkg: "#E9ECEF",
-            nodeBorder: "#0063B2",
-            actorBkg: "#E9ECEF",
-            actorBorder: "#0063B2",
-            actorTextColor: "#1A1A1A",
-            actorLineColor: "#6B7280",
-            signalColor: "#1A1A1A",
-            signalTextColor: "#1A1A1A",
-            labelBoxBkgColor: "#FFFFFF",
-            labelBoxBorderColor: "#0063B2",
-            labelTextColor: "#1A1A1A",
-            loopTextColor: "#1A1A1A",
-            noteBkgColor: "#FFFFFF",
-            noteTextColor: "#1A1A1A",
-            noteBorderColor: "#0063B2",
-            activationBkgColor: "#E9ECEF",
-            activationBorderColor: "#0063B2",
-            sequenceNumberColor: "#FFFFFF",
-          },
-      flowchart: { useMaxWidth: true },
-      sequence: { useMaxWidth: true },
-    });
+    try {
+      const result = await mermaid.render(id, chart.trim());
+      if (signal.cancelled) return;
 
-    mermaid
-      .render(id, chart.trim())
-      .then(({ svg: renderedSvg }) => {
-        setSvg(renderedSvg);
-        setError("");
-      })
-      .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        setError(message);
-      });
+      bindFunctionsRef.current = result.bindFunctions ?? null;
+      setSvg(result.svg);
+      setError("");
+    } catch (err: unknown) {
+      if (signal.cancelled) return;
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+    }
   }, [chart, resolvedTheme]);
+
+  useEffect(() => {
+    const signal = { cancelled: false };
+    renderDiagram(signal);
+    return () => { signal.cancelled = true; };
+  }, [renderDiagram]);
+
+  // Call bindFunctions after the SVG is injected into the DOM so that
+  // mermaid event handlers (link clicks, tooltips) work correctly.
+  useEffect(() => {
+    if (svg && containerRef.current && bindFunctionsRef.current) {
+      bindFunctionsRef.current(containerRef.current);
+    }
+  }, [svg]);
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary

- Add two blog posts for the brokered Docker socket (DinD) feature: a technical deep dive and a setup guide
- Add mermaid diagram support to the blog via a new `MermaidDiagram` client component with `next-themes` integration for automatic light/dark mode switching and brand-color-matched theme variables
- Wire mermaid into the MDX `pre` handler so ` ```mermaid ` code blocks render as interactive diagrams with optional `title="..."` support

## Test plan

- [ ] Both blog posts render at their URLs with correct frontmatter, code highlighting, and tables
- [ ] Mermaid diagrams render (3 in the technical post: request flow sequence, standard mode flowchart, airlock mode flowchart)
- [ ] Mermaid diagrams use blog brand colors (blue `#0063B2` in light, cyan `#46CBFF` in dark)
- [ ] Mermaid diagrams re-render on theme toggle
- [ ] Mermaid diagram titles display with the same header bar style as code blocks
- [ ] Cross-links between posts and to copilot_here site are correct
- [ ] Known #101 limitation mentioned in both posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)