### PR TITLE
fix: keep draft field in Tina schema to unblock CI

### DIFF
--- a/tina/config.ts
+++ b/tina/config.ts
@@ -17,6 +17,13 @@ const schema = defineSchema({
         { type: "datetime", name: "date", label: "Date", required: true },
         { type: "string", name: "tags", label: "Tags", list: true },
         { type: "datetime", name: "lastmod", label: "Last Modified" },
+        // Kept only to keep the TinaCloud remote schema happy — removing a field
+        // is a breaking change and the `tinacms build` in CI bails before it can
+        // push the new schema. Draft is no longer read anywhere in the codebase;
+        // no blog post has ever had `draft: true`, and the filter helpers were
+        // removed. Field stays here purely as a placeholder until we can safely
+        // drop it via TinaCloud's breaking-change approval flow.
+        { type: "boolean", name: "draft", label: "Draft" },
         { type: "string", name: "summary", label: "Summary", ui: { component: "textarea" } },
         { type: "string", name: "canonicalUrl", label: "Canonical URL" },
         {

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -23,7 +23,18 @@ const schema = defineSchema({
         // no blog post has ever had `draft: true`, and the filter helpers were
         // removed. Field stays here purely as a placeholder until we can safely
         // drop it via TinaCloud's breaking-change approval flow.
-        { type: "boolean", name: "draft", label: "Draft" },
+        //
+        // `ui.component: () => null` hides the field from the Tina admin form so
+        // editors can't toggle it by mistake and Tina doesn't write `draft:` back
+        // into post frontmatter on save.
+        {
+          type: "boolean",
+          name: "draft",
+          label: "Draft (deprecated — schema-compat placeholder)",
+          description:
+            "Unused. Kept to avoid a breaking TinaCloud schema change; hidden in the admin so editors don't re-introduce it into frontmatter.",
+          ui: { component: () => null },
+        },
         { type: "string", name: "summary", label: "Summary", ui: { component: "textarea" } },
         { type: "string", name: "canonicalUrl", label: "Canonical URL" },
         {


### PR DESCRIPTION
## Summary

Removing the `draft` field from the Tina schema (done in #236) is treated by TinaCloud as a breaking change. `tinacms build` in CI checks the local schema against the remote and bails — which means the deploy can't push the new schema, which means the remote never updates. Chicken-and-egg.

Quickest unblock: keep the `draft` field in `tina/config.ts` only. Nothing else reads it:

- `PostMeta` doesn't declare `draft` (removed in #236).
- `getPublishedPosts` / `filterPublishedPosts` are gone.
- No blog post has ever had `draft: true`.
- No frontmatter across the 191 posts has `draft:` anymore.

So it's a purely schema-level placeholder that keeps Tina happy without resurrecting any dead-weight logic. When we're ready, we can approve the breaking-schema change via TinaCloud's flow and drop the field for real in a follow-up.

## Test plan

- [ ] `pnpm exec tsc --noEmit` passes locally (did — no consumers of `draft`).
- [ ] Deploy workflow (re-run of run 24786471704) passes the `tinacms build` step.
- [ ] After deploy, admin panel at `/admin` loads normally.