### PR TITLE
fix: drop ui.component function from draft field — breaks Tina schema check

### DIFF
--- a/tina/config.ts
+++ b/tina/config.ts
@@ -24,16 +24,19 @@ const schema = defineSchema({
         // removed. Field stays here purely as a placeholder until we can safely
         // drop it via TinaCloud's breaking-change approval flow.
         //
-        // `ui.component: () => null` hides the field from the Tina admin form so
-        // editors can't toggle it by mistake and Tina doesn't write `draft:` back
-        // into post frontmatter on save.
+        // We tried hiding the field with `ui.component: () => null`, but the
+        // inline function doesn't serialize cleanly when Tina pushes the schema
+        // up to the cloud — the indexed remote schema ends up missing the `ui`
+        // block, and `tinacms build`'s local/remote equality check fails on
+        // every run. Keeping the shape as a plain boolean matches whatever Tina
+        // ultimately indexes, so the check stays happy. Editors will see a
+        // "(deprecated)" checkbox in the admin; the label is the only deterrent.
         {
           type: "boolean",
           name: "draft",
-          label: "Draft (deprecated — schema-compat placeholder)",
+          label: "Draft (deprecated — do not toggle)",
           description:
-            "Unused. Kept to avoid a breaking TinaCloud schema change; hidden in the admin so editors don't re-introduce it into frontmatter.",
-          ui: { component: () => null },
+            "Unused. Kept only to avoid a breaking TinaCloud schema change.",
         },
         { type: "string", name: "summary", label: "Summary", ui: { component: "textarea" } },
         { type: "string", name: "canonicalUrl", label: "Canonical URL" },


### PR DESCRIPTION
## Summary

Follow-up to #237. Even with `draft` back in the schema, `tinacms build` kept failing on main with "local Tina schema doesn't match the remote Tina schema". The deploy run at 21:00 confirmed TinaCloud had re-indexed (`Last indexed at: 20:58:52`, two minutes before the build) — the remote was fresh, the schemas just didn't compare equal.

Most likely cause: the inline `ui: { component: () => null }` we added in #237 to hide the deprecated field. Tina strips functions when it serializes the schema for cloud indexing, so the indexed shape ends up without the `ui` block, while the local copy still has it — `tinacms build`'s equality check then fails every time.

Simplest unblock: revert the hiding attempt. Keep `draft` as a plain boolean whose shape matches exactly what Tina indexes, so the check passes. Re-label and describe it so editors opening the admin get a clear "do not touch" cue:

```ts
{
  type: "boolean",
  name: "draft",
  label: "Draft (deprecated — do not toggle)",
  description: "Unused. Kept only to avoid a breaking TinaCloud schema change.",
},
```

We revisit a real hide (or full removal via TinaCloud's breaking-change approval) once main is deploying cleanly again.

## Test plan

- [ ] `pnpm exec tsc --noEmit` passes locally.
- [ ] After merge, the next deploy workflow's `tinacms build` step no longer errors with the schema-mismatch message.
- [ ] /admin loads without regression; the `draft` field shows up labelled as deprecated.