### PR TITLE
fix: stop nugget iframe nesting; serve raw at /nuggets/_raw/<slug>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,11 @@
 /build
 
 # generated at build time by scripts/copy-nuggets.mjs — mirror of
-# content/nuggets/*.html. _resize.js is source so keep it tracked.
+# content/nuggets/*.html into /_raw/ (kept out of the Next route path to
+# avoid colliding with out/nuggets/<slug>.html). _resize.js is source so
+# keep it tracked; the legacy /public/nuggets/*.html pattern stays to
+# cover any stray top-level copies from older builds.
+/public/nuggets/_raw/
 /public/nuggets/*.html
 
 # misc

--- a/scripts/copy-nuggets.mjs
+++ b/scripts/copy-nuggets.mjs
@@ -2,15 +2,15 @@ import { existsSync, mkdirSync, readdirSync, copyFileSync, unlinkSync, statSync 
 import path from 'path';
 
 const contentDir = './content/nuggets';
-const publicDir = './public/nuggets';
-
-// Preserve _resize.js (owned by this repo, not by per-nugget content) while
-// clearing out stale nugget HTML from previous builds.
-const PRESERVE = new Set(['_resize.js']);
+// Raw nugget HTML lives under /_raw/ so it doesn't collide with Next's
+// static-export output for the /nuggets/[slug] route. Next writes
+// out/nuggets/<slug>.html for the chromed page; if the raw file were at the
+// same path, Next's output would overwrite it during build and the iframe
+// would end up embedding the chromed page — infinite iframe nesting.
+const publicDir = './public/nuggets/_raw';
 
 if (existsSync(publicDir)) {
   for (const file of readdirSync(publicDir)) {
-    if (PRESERVE.has(file)) continue;
     try { unlinkSync(path.join(publicDir, file)); } catch (e) { console.error(e); }
   }
 } else {

--- a/scripts/copy-nuggets.mjs
+++ b/scripts/copy-nuggets.mjs
@@ -2,15 +2,15 @@ import { existsSync, mkdirSync, readdirSync, copyFileSync, rmSync, statSync } fr
 import path from 'path';
 
 const contentDir = './content/nuggets';
-// Raw nugget HTML lives under /_raw/<slug>/index.html so it:
-//  1. Doesn't collide with Next's static-export output for /nuggets/[slug]
-//     (Next writes out/nuggets/<slug>.html for the chromed page; same filename
-//     at the top level would be overwritten and the iframe would embed the
-//     chromed page → infinite iframe nesting).
-//  2. Resolves at /nuggets/_raw/<slug> with no ".html" in the visible URL,
-//     matching the extensionless style used elsewhere on the site (blog,
-//     tags, years). The directory-with-index layout makes this work on any
-//     static host — no reliance on host-specific extension stripping.
+// Raw nugget HTML is exposed at /nuggets/_raw/<slug>, backed by
+// public/nuggets/_raw/<slug>/index.html. This keeps it:
+//  1. Clear of collision with Next's static-export output for /nuggets/[slug]
+//     (Next writes out/nuggets/<slug>.html for the chromed page; if the raw
+//     file were at that same filename it would be overwritten and the iframe
+//     would embed the chromed page → infinite iframe nesting).
+//  2. Extensionless in the visible URL — matching blog, tags, years — with
+//     no reliance on host-specific .html stripping, since the directory +
+//     index.html layout resolves on any static host.
 const publicDir = './public/nuggets/_raw';
 
 if (existsSync(publicDir)) {

--- a/scripts/copy-nuggets.mjs
+++ b/scripts/copy-nuggets.mjs
@@ -1,21 +1,22 @@
-import { existsSync, mkdirSync, readdirSync, copyFileSync, unlinkSync, statSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, copyFileSync, rmSync, statSync } from 'fs';
 import path from 'path';
 
 const contentDir = './content/nuggets';
-// Raw nugget HTML lives under /_raw/ so it doesn't collide with Next's
-// static-export output for the /nuggets/[slug] route. Next writes
-// out/nuggets/<slug>.html for the chromed page; if the raw file were at the
-// same path, Next's output would overwrite it during build and the iframe
-// would end up embedding the chromed page — infinite iframe nesting.
+// Raw nugget HTML lives under /_raw/<slug>/index.html so it:
+//  1. Doesn't collide with Next's static-export output for /nuggets/[slug]
+//     (Next writes out/nuggets/<slug>.html for the chromed page; same filename
+//     at the top level would be overwritten and the iframe would embed the
+//     chromed page → infinite iframe nesting).
+//  2. Resolves at /nuggets/_raw/<slug> with no ".html" in the visible URL,
+//     matching the extensionless style used elsewhere on the site (blog,
+//     tags, years). The directory-with-index layout makes this work on any
+//     static host — no reliance on host-specific extension stripping.
 const publicDir = './public/nuggets/_raw';
 
 if (existsSync(publicDir)) {
-  for (const file of readdirSync(publicDir)) {
-    try { unlinkSync(path.join(publicDir, file)); } catch (e) { console.error(e); }
-  }
-} else {
-  mkdirSync(publicDir, { recursive: true });
+  rmSync(publicDir, { recursive: true, force: true });
 }
+mkdirSync(publicDir, { recursive: true });
 
 if (!existsSync(contentDir)) {
   console.log(`No ${contentDir} directory found; skipping nugget copy.`);
@@ -27,9 +28,11 @@ for (const entry of readdirSync(contentDir)) {
   const src = path.join(contentDir, entry);
   if (!statSync(src).isFile()) continue;
   if (!entry.endsWith('.html')) continue;
-  const dest = path.join(publicDir, entry);
-  copyFileSync(src, dest);
+  const slug = entry.replace(/\.html$/, '');
+  const destDir = path.join(publicDir, slug);
+  mkdirSync(destDir, { recursive: true });
+  copyFileSync(src, path.join(destDir, 'index.html'));
   copied += 1;
 }
 
-console.log(`Copied ${copied} nugget(s) from ${contentDir} to ${publicDir}`);
+console.log(`Copied ${copied} nugget(s) from ${contentDir} to ${publicDir}/<slug>/index.html`);

--- a/src/app/nuggets/[slug]/page.tsx
+++ b/src/app/nuggets/[slug]/page.tsx
@@ -59,10 +59,11 @@ export default async function NuggetPage(props: PageProps) {
     notFound();
   }
 
-  // Raw nugget HTML is served from /_raw/<slug>/index.html to avoid colliding
-  // with Next's static-export output for this very route (which writes
-  // out/nuggets/<slug>.html for the chromed page). Directory + index.html so
-  // the URL works extensionless on any static host. See scripts/copy-nuggets.mjs.
+  // Raw nugget HTML is exposed at /nuggets/_raw/<slug>, backed by
+  // public/nuggets/_raw/<slug>/index.html, to avoid colliding with Next's
+  // static-export output for this very route (which writes
+  // out/nuggets/<slug>.html for the chromed page). Directory + index.html keeps
+  // the public URL extensionless on static hosts. See scripts/copy-nuggets.mjs.
   const rawUrl = `/nuggets/_raw/${nugget.slug}`;
 
   return (

--- a/src/app/nuggets/[slug]/page.tsx
+++ b/src/app/nuggets/[slug]/page.tsx
@@ -59,7 +59,10 @@ export default async function NuggetPage(props: PageProps) {
     notFound();
   }
 
-  const rawUrl = `/nuggets/${nugget.slug}.html`;
+  // Raw nugget HTML is served from /_raw/ to avoid colliding with Next's
+  // static-export output for this very route (which writes
+  // out/nuggets/<slug>.html for the chromed page). See scripts/copy-nuggets.mjs.
+  const rawUrl = `/nuggets/_raw/${nugget.slug}.html`;
 
   return (
     <article className="pb-12">

--- a/src/app/nuggets/[slug]/page.tsx
+++ b/src/app/nuggets/[slug]/page.tsx
@@ -59,10 +59,11 @@ export default async function NuggetPage(props: PageProps) {
     notFound();
   }
 
-  // Raw nugget HTML is served from /_raw/ to avoid colliding with Next's
-  // static-export output for this very route (which writes
-  // out/nuggets/<slug>.html for the chromed page). See scripts/copy-nuggets.mjs.
-  const rawUrl = `/nuggets/_raw/${nugget.slug}.html`;
+  // Raw nugget HTML is served from /_raw/<slug>/index.html to avoid colliding
+  // with Next's static-export output for this very route (which writes
+  // out/nuggets/<slug>.html for the chromed page). Directory + index.html so
+  // the URL works extensionless on any static host. See scripts/copy-nuggets.mjs.
+  const rawUrl = `/nuggets/_raw/${nugget.slug}`;
 
   return (
     <article className="pb-12">


### PR DESCRIPTION
## Summary

- Raw nugget HTML was being served at `/nuggets/<slug>.html`, the same path Next's static export writes the chromed page to. Next won the filename collision, so the iframe on `/nuggets/<slug>` ended up embedding the chromed page — which itself contained another iframe at the same URL — producing infinite iframe nesting and no nugget content visible.
- Move the raw copy under a sub-path that can't collide: `public/nuggets/_raw/<slug>/index.html`. Underscore-prefixed segments can never be valid slugs (regex is `^[a-z0-9]...`), so the collision can't reappear.
- Reference the raw HTML as `/nuggets/_raw/<slug>` (extensionless, directory + `index.html`). URL style matches blog, tags, years; works on any static host without relying on host-specific `.html` stripping.

## What changed

- `scripts/copy-nuggets.mjs` — copies `content/nuggets/<slug>.html` to `public/nuggets/_raw/<slug>/index.html`; clears the whole `_raw/` tree each run.
- `src/app/nuggets/[slug]/page.tsx` — iframe `src` and "Open raw ↗" href now use `/nuggets/_raw/<slug>`.
- `.gitignore` — ignores `/public/nuggets/_raw/` (generated) while keeping `_resize.js` tracked.
- Removed the previously-tracked `public/nuggets/webcrypto-aes-gcm-explainer.html` — it was an accidental checkin of the copied file.

## Test plan

- [ ] `pnpm build` succeeds; `out/nuggets/_raw/<slug>/index.html` contains the raw explainer (first line `<!DOCTYPE html>` + its own `<head>`), not the chromed Next page.
- [ ] `out/nuggets/<slug>.html` still renders the Next chromed page and references `/nuggets/_raw/<slug>` for the iframe.
- [ ] Serving the build locally: `/nuggets/webcrypto-aes-gcm-explainer` shows the site chrome exactly once, with the AES-GCM explainer rendered inside the iframe (no scrollbar, parent auto-sizes via the resize shim).
- [ ] "Open raw ↗" opens the standalone page with no site chrome.
- [ ] Deploy preview: `curl -s https://<preview>/nuggets/_raw/webcrypto-aes-gcm-explainer | head -c 100` returns `<!DOCTYPE html><html lang="en">…` (not the Next document).