### PR TITLE
blog: migrating from Ghostty to cmux

### DIFF
--- a/content/blog/2026-04-24/cmux-migration-from-ghostty.mdx
+++ b/content/blog/2026-04-24/cmux-migration-from-ghostty.mdx
@@ -1,0 +1,80 @@
+---
+title: 'Migrating from Ghostty to cmux'
+date: 2026-04-24
+tags: ['Terminal', 'cmux', 'Ghostty', 'AI', 'Productivity', 'macOS']
+summary: 'cmux is built on libghostty and reads my existing ~/.config/ghostty/config, so the move from Ghostty was effectively a relaunch. Here is what it actually got me: workspaces with PR status in the sidebar and an embedded browser for opening plans and PRs next to the terminal that owns them.'
+---
+
+A few weeks ago I [migrated my whole terminal stack to Ghostty](/blog/2026-03-06/i-let-claude-migrate-my-entire-terminal-setup) and then [hooked the tab titles to git repo names](/blog/2026-03-11/ghostty-tab-titles-from-git-repo-names) so I could tell my Claude Code panels apart. Ghostty has been good. Fast, clean, no AI panel chrome creeping in.
+
+So why move again? Two things [cmux](https://cmux.com) does that Ghostty doesn't.
+
+## Why cmux
+
+### A sidebar that knows about my work
+
+cmux puts a vertical tab strip down the left edge, and each entry shows the git branch, the linked PR number and status, the working directory, and any ports the workspace is listening on. With four or five repos open across an afternoon, that sidebar is the project switcher I've been faking with tab titles for months.
+
+### An embedded browser pane
+
+This is the one I really wanted. When I'm reviewing a PR or stepping through a [Plannotator](https://github.com/gordonbeeming/plannotator) plan, I want the page next to the terminal that produced it, not on a separate monitor in a different app. cmux ships a Chromium-based browser pane that splits like any other terminal pane. Open the PR, scroll on one side, type on the other.
+
+That was enough to make me try it. The thing I didn't expect was how cheap "trying it" was.
+
+## The "migration"
+
+```sh title="install.sh"
+brew install --cask cmux
+```
+
+That's the whole thing.
+
+cmux is built on [libghostty](https://github.com/ghostty-org/ghostty), the same terminal engine Ghostty itself uses, and it reads my existing `~/.config/ghostty/config` directly. Theme, font, and working directory all carried over without me touching a file.
+
+I launched it, my Monokai Pro theme was already on, MonaspiceNe was already the font, the first window opened in `~/Developer/github`. Done. No copy-paste, no symlink, no `cmux.json`, no rewrite of keybindings.
+
+cmux also defaults `macos-auto-secure-input` to `true`, so Secure Keyboard Entry kicks in automatically at password prompts without any extra setup. Here's the entire config cmux is reading:
+
+```text title="~/.config/ghostty/config"
+window-theme = dark
+theme = dark:Monokai Pro,light:Monokai Pro Light
+font-family = "MonaspiceNe Nerd Font"
+font-size = 13
+copy-on-select = false
+clipboard-trim-trailing-spaces = false
+working-directory = /Users/gordonbeeming/Developer/github
+window-inherit-working-directory = true
+macos-auto-secure-input = true
+```
+
+## What I'm getting that I wasn't before
+
+### The sidebar
+
+Each workspace shows me the branch I'm on and the PR number and state for that branch. Glancing at the sidebar tells me which repo has a PR in review, which one has a draft, and which one I haven't pushed yet. I used to keep a GitHub tab open just to know that. Now it's two pixels to the left of my terminal.
+
+### The browser pane
+
+I split a workspace horizontally (terminal on the left, browser on the right) and point the browser at the PR. When the AI coding client in the terminal pane finishes a change, I refresh the diff on the right and review it without leaving the workspace. Same flow for plan review with Plannotator: the plan renders next to the agent that's about to execute it, and I'm reading both in the same window.
+
+### Notifications
+
+cmux picks up the OSC 9 / 99 / 777 sequences that agents emit and surfaces them in the sidebar entry for the workspace that fired them. So if a long-running task in the `xylem` workspace finishes while I'm in the `copilot_here` workspace, the `xylem` entry blinks at me. Whichever AI coding client you use (Claude Code, Codex, OpenCode, Aider, Copilot CLI), you can wire it through `cmux notify` to plug into this.
+
+## Cleanup
+
+Once I'd had a day with it and confirmed nothing was missing, removing the old terminal was a one-liner:
+
+```sh title="uninstall.sh"
+brew uninstall --cask ghostty
+```
+
+I left `~/.config/ghostty/config` exactly where it was. cmux still reads it, and if I ever want to fall back to Ghostty I just `brew install --cask ghostty` again and everything snaps back into place.
+
+The `.zshrc` tab-title hook stays put for the same reason. It's terminal-agnostic, just an escape sequence.
+
+## What I'd tell you
+
+If you're already on Ghostty and even mildly curious about the workspaces or the browser pane, the cost to try cmux is roughly zero. Your theme and font and tab titles all carry over the first time you launch, and if you don't like it you can drop back to Ghostty without losing any config.
+
+Most stack swaps cost me an afternoon. This one cost me about as long as it took to drag a browser pane next to a terminal pane.


### PR DESCRIPTION
## Summary

- New blog post at `content/blog/2026-04-24/cmux-migration-from-ghostty.mdx` covering the move from Ghostty to cmux
- Angle: cmux is built on libghostty and reads `~/.config/ghostty/config` natively, so "migration" is a `brew install` and a relaunch
- Calls out the two cmux-specific wins that prompted the switch (workspaces sidebar with PR status, embedded browser pane for inline plan/PR review) and the one config-level note worth knowing (`macos-auto-secure-input` defaults to `true`, so SKE is on by default)
- Follow-on to the [2026-03-06](/blog/2026-03-06/i-let-claude-migrate-my-entire-terminal-setup) and [2026-03-11](/blog/2026-03-11/ghostty-tab-titles-from-git-repo-names) posts

## Test plan

- [ ] `pnpm dev` renders the new post at `/blog/2026-04-24/cmux-migration-from-ghostty` without MDX errors
- [ ] Code blocks (`install.sh`, `~/.config/ghostty/config`, `uninstall.sh`) all show the title bar correctly via the shiki transformer
- [ ] Internal links to the two prior posts resolve
- [ ] External links to cmux.com, libghostty repo, Plannotator repo open correctly
- [ ] Post appears on the homepage and in the year + tag indexes (`/years/2026`, `/tags/terminal`, `/tags/cmux`, etc.)
- [ ] Feed generation (`/feed.xml`, `/atom.xml`, `/feed.json`) includes the post