### PR TITLE
Smooth choppy sentence rhythm in runtime dependency post

### DIFF
--- a/content/blog/2026-06-18/your-experience-is-a-runtime-dependency.mdx
+++ b/content/blog/2026-06-18/your-experience-is-a-runtime-dependency.mdx
@@ -27,7 +27,7 @@ But someone with a few years of real work behind them usually knows things that 
 
 That's the gap with agents too.
 
-The agent isn't short on raw intelligence, it's short on runtime context.
+The agent isn't short on raw intelligence, just on runtime context.
 
 It doesn't know your team conventions unless you give them to it. It doesn't know your preferred validation flow unless you write it down. It doesn't know your taste in PR descriptions, your tolerance for risk, your habits around issue planning, or the little repo-specific commands that make the difference between "technically works" and "works the way we work here."
 

--- a/content/blog/2026-06-18/your-experience-is-a-runtime-dependency.mdx
+++ b/content/blog/2026-06-18/your-experience-is-a-runtime-dependency.mdx
@@ -2,7 +2,7 @@
 title: 'Your experience is a runtime dependency'
 date: 2026-06-18
 tags: ['AI', 'Agents', 'Agentic Engineering', 'Skills', 'Productivity', 'Software Development']
-summary: 'AI agents are already very capable, but they do not automatically have the judgement that makes you effective in your current role. Skills and agent instructions are how you package that experience so the agent can use it.'
+summary: "AI agents are already very capable, but they don't automatically have the judgement that makes you effective in your current role. Skills and agent instructions are how you package that experience so the agent can use it."
 ---
 
 I was explaining something to [Jack Pettit](https://www.linkedin.com/in/jackdevau/) earlier and the analogy landed better than I expected.
@@ -19,15 +19,15 @@ The model can be brilliant in the general sense and still be missing the depende
 
 The way I explained it was a bit like onboarding a very sharp new starter.
 
-They might have just finished studying. They might know the newer tools better than you do. They might be quicker at finding patterns, quicker at reading docs, and less attached to the way things were done five years ago.
+They might have just finished studying and know the newer tools better than you do. They might be quicker at finding patterns, quicker at reading docs, and less attached to the way things were done five years ago.
 
-Great. That is useful.
+Great, that's useful.
 
 But someone with a few years of real work behind them usually knows things that are hard to teach in a classroom. They know what "done" means on a real team. They know when a shortcut is fine and when it becomes a support ticket. They know that the Jira ticket is often missing the actual requirement. They know which parts of the system are safe to touch and which parts look simple because the complexity is hidden in the business rules.
 
-That is the gap with agents too.
+That's the gap with agents too.
 
-The agent is not short on raw intelligence. It is short on runtime context.
+The agent isn't short on raw intelligence, it's short on runtime context.
 
 It doesn't know your team conventions unless you give them to it. It doesn't know your preferred validation flow unless you write it down. It doesn't know your taste in PR descriptions, your tolerance for risk, your habits around issue planning, or the little repo-specific commands that make the difference between "technically works" and "works the way we work here."
 
@@ -37,7 +37,7 @@ So when we complain that agents produce generic output, sometimes the uncomforta
 
 This is where skills, `AGENTS.md`, `CLAUDE.md`, and repo instructions start to matter.
 
-I don't think of those as prompt hacks anymore. They are closer to packaging your working habits so the agent can load them at the right time.
+I don't think of those as prompt hacks anymore. They're closer to packaging your working habits so the agent can load them at the right time.
 
 Some of that belongs globally:
 
@@ -63,9 +63,9 @@ And some of it belongs in skills:
 - how to write in your voice
 - how to handle a workflow you repeat often enough that rediscovering it every session is waste
 
-The goal is not to bury the model under rules. I have done that too, and it gets slow and annoying quickly. The goal is to make the important context available where it helps.
+The goal is not to bury the model under rules. I've done that too, and it gets slow and annoying quickly. The goal is to make the important context available where it helps.
 
-A good skill is not "think exactly like me." It is "when doing this kind of task, here are the constraints, examples, tools, and checks that make the result acceptable."
+A good skill isn't "think exactly like me." It's "when doing this kind of task, here are the constraints, examples, tools, and checks that make the result acceptable."
 
 That tends to age better.
 
@@ -73,31 +73,31 @@ That tends to age better.
 
 The other part of the analogy is that every new model feels a bit like the next year's intake.
 
-Better trained. More capable. More current. Less likely to get stuck on the things the previous one struggled with.
+Better trained, more capable, more current, and less likely to get stuck on the things the previous one struggled with.
 
 But the new model still doesn't know your history by default.
 
-That is why I think the context you build around agents compounds. If you put your experience only into one-off prompts, it disappears at the end of the session. If you put it into durable skills and instructions, the next model gets to inherit it too.
+That's why I think the context you build around agents compounds. If you put your experience only into one-off prompts, it disappears at the end of the session, but if you put it into durable skills and instructions, the next model gets to inherit it too.
 
-That is the interesting bit for me.
+That's the interesting bit for me.
 
-You are using this year's model better, but you are also building a small layer of your own professional context that can travel forward as the tools improve.
+You're using this year's model better, but you're also building a small layer of your own professional context that can travel forward as the tools improve.
 
 The agent gets smarter underneath. Your context gets more useful on top.
 
 ## This is also engineering work
 
-There is a trap here where people hear "write better prompts" and think this is about being clever with wording.
+There's a trap here where people hear "write better prompts" and think this is about being clever with wording.
 
-I don't think that is the job.
+I don't think that's the job.
 
 The job is closer to making implicit engineering judgement explicit enough that an agent can use it.
 
 If you always check unresolved GitHub review threads a certain way because the simpler command misses inline comments, write that down. If a repo has one command that looks like it runs the tests but does not cover the important path, write that down. If you keep correcting agents for the same formatting, planning, validation, or artifact mistakes, turn the correction into a skill or instruction.
 
-Not every correction deserves a rule. Some mistakes are one-offs. Some are the model having a bad day. Some are your request being vague.
+Not every correction deserves a rule. Some mistakes are one-offs, some are the model having a bad day, and some are just your request being vague.
 
-But when the same correction keeps coming back, that is usually a missing dependency.
+But when the same correction keeps coming back, that's usually a missing dependency.
 
 Package it.
 
@@ -105,13 +105,13 @@ Package it.
 
 Two developers can use the same model and get very different results.
 
-Part of that is the prompt in the moment, sure. But more and more, I think the bigger difference is the environment around the model. The skills. The repo instructions. The examples. The little bits of scar tissue that have been turned into reusable guidance.
+Part of that is the prompt in the moment, sure, but more and more I think the bigger difference is the environment around the model. The skills, repo instructions, examples, etc... The little bits of scar tissue that have been turned into reusable guidance.
 
 Nobody else has exactly your experience. Nobody else has your exact set of projects, customers, outages, habits, preferences, and tradeoffs.
 
 If you do this properly, the agent becomes better at producing the kind of work you would have produced, with the speed and breadth the model brings.
 
-That is the part worth paying attention to.
+That's the part worth paying attention to.
 
 The agent is already smart. The missing piece is experience.
 


### PR DESCRIPTION
## Summary

- Joins staccato fragment-lists into flowing sentences (e.g. `The skills. The repo instructions. The examples.` → `The skills, repo instructions, examples, etc...`) per Luke Cook's note that the clipped rhythm reads as AI-written.
- Swaps stiff full forms for contractions throughout (`that is`→`that's`, `it is`→`it's`, `you are`→`you're`), including the frontmatter summary.
- Keeps the deliberate one-line beats and anaphora that are intentional voice, not choppiness.

## Test plan

- [ ] `pnpm build` renders the post without MDX/frontmatter errors
- [ ] Post reads with varied rhythm, no machine-gun fragment runs