### PR TITLE
Order projects by lifecycle then stars

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -19,16 +19,10 @@ export const metadata: Metadata = {
 // Group projects by lifecycle before ordering by popularity: live projects
 // first, then private previews, then deprecated ones at the bottom.
 function statusTier(status?: string): number {
-  switch (status?.trim().toLowerCase()) {
-    case "deprecated":
-      return 2;
-    case undefined:
-    case "":
-      return 0;
-    default:
-      // Any other status (currently "Private preview") sits between the two.
-      return 1;
-  }
+  const normalized = status?.trim().toLowerCase();
+  if (!normalized) return 0;
+  // Any other status (currently "Private preview") sits between live and deprecated.
+  return normalized === "deprecated" ? 2 : 1;
 }
 
 export default async function ProjectsPage() {

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -16,9 +16,26 @@ export const metadata: Metadata = {
   },
 };
 
+// Group projects by lifecycle before ordering by popularity: live projects
+// first, then private previews, then deprecated ones at the bottom.
+function statusTier(status?: string): number {
+  switch (status?.trim().toLowerCase()) {
+    case "deprecated":
+      return 2;
+    case undefined:
+    case "":
+      return 0;
+    default:
+      // Any other status (currently "Private preview") sits between the two.
+      return 1;
+  }
+}
+
 export default async function ProjectsPage() {
   const projects = (await enrichProjectsWithStars(getAllProjects())).sort(
     (a, b) => {
+      const tier = statusTier(a.status) - statusTier(b.status);
+      if (tier !== 0) return tier;
       const stars = (b.githubStars ?? 0) - (a.githubStars ?? 0);
       if (stars !== 0) return stars;
       return a.title.localeCompare(b.title);


### PR DESCRIPTION
## Summary

Groups the `/projects` page by lifecycle before ranking by popularity:

1. Live projects (no status)
2. Private previews
3. Deprecated

Within each group, projects still sort by star count (then title). Implemented with a `statusTier` helper feeding the existing comparator. The home-page featured set is unaffected (all featured projects are live).

## Test plan

- `npx tsc --noEmit` — clean.
- Ran `pnpm dev` and confirmed the rendered `/projects` order: copilot_here, Insomnia, Claude/Codex Statusline, Claude Recall, HardPhase Tracker, Privileges Monitor, Scribe, Stub, Vista, ClaudeBar (live, by stars), then PullUp, shunt (private preview), then ClaudeNest (deprecated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXPFVbzsDWT69ZTeiEVn5H