### PR TITLE
Pin deploy workflow actions to SHA, bump majors to clear Node 20 warning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,15 +24,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -53,7 +53,7 @@ jobs:
         run: pnpm build:tina
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./out
 
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Summary

- The last deploy run ([29045896617](https://github.com/GordonBeeming/xylem/actions/runs/29045896617)) warned that `checkout@v4`, `setup-node@v4`, `upload-pages-artifact@v3`, and `action-setup@v4` (pnpm) target Node 20, which GitHub is deprecating — the runner was silently forcing them onto Node 24 to keep working. Bumped all five actions (including `deploy-pages`) to their latest majors, which target Node 24 natively.
- Checked each release's changelog for anything relevant to our usage — none found; `pnpm`'s `version` input, `setup-node`'s `node-version`/`cache` inputs, and the artifact `path` are all unchanged across the version jumps.
- Pinned every action to its exact commit SHA instead of a mutable version tag, per GitHub's supply-chain hardening guidance — a tag can be force-moved to point at different code without our workflow changing; a SHA can't. Kept a trailing `# vX.Y.Z` comment on each line so the pinned version stays human-readable.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — valid YAML.
- Verified every pinned SHA resolves to the exact tagged release via the GitHub API before pinning.
- Reviewed `actions/checkout` v5/v6/v7, `pnpm/action-setup` v5/v6, `actions/setup-node`, `actions/upload-pages-artifact`, and `actions/deploy-pages` release notes for breaking changes affecting our simple usage — none found.
- Next actual deploy run (on merge to `main`) will confirm the Node 20 warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZLEe3foCGkzuvQ2f78LKB