### PR TITLE
Add CodexBar project

### DIFF
--- a/content/projects/codex-bar.json
+++ b/content/projects/codex-bar.json
@@ -1,0 +1,12 @@
+{
+  "title": "CodexBar",
+  "description": "Your Codex usage limits in the macOS menu bar, in your timezone. Shows session and weekly usage, reset times, pace indicators, and model-specific limits straight from Codex. No cost tracking, no charts, just the numbers you need at a glance.",
+  "techStack": [
+    "Swift",
+    "SwiftUI",
+    "macOS"
+  ],
+  "github": "https://github.com/GordonBeeming/codex-bar",
+  "date": "2026-07-09",
+  "featured": false
+}


### PR DESCRIPTION
## Summary

- add CodexBar to the projects collection
- include its purpose, Swift/SwiftUI/macOS stack, repository link, and launch date

## Why

CodexBar should be discoverable alongside the other projects on Xylem.

## User impact

Visitors can find CodexBar from the projects listing, homepage project content, and generated search index, including live GitHub metadata where available.

## Validation

- `jq empty content/projects/codex-bar.json`
- `git diff --check`
- `pnpm build`