### PR TITLE
Fix Claude Statusline project details

### DIFF
--- a/content/projects/claude-statusline.json
+++ b/content/projects/claude-statusline.json
@@ -1,12 +1,11 @@
 {
-  "title": "Claude / Codex Statusline",
-  "description": "Multi-line status line for Claude Code, with a sibling build for Codex. Shows repo, GitButler/git branch, model + effort, session and daily cost, rate-limit progress, and context/token usage across four lines.",
+  "title": "Claude Statusline",
+  "description": "Multi-line status line for Claude Code. Shows repo, GitButler/git branch, model, session and daily cost, rate-limit progress, and context/token usage across four lines.",
   "href": "https://github.com/GordonBeeming/claude-statusline",
   "imgSrc": "/static/images/projects/claude-statusline.png",
   "techStack": [
     "Shell",
-    "Claude Code",
-    "Codex"
+    "Claude Code"
   ],
   "github": "https://github.com/GordonBeeming/claude-statusline",
   "date": "2026-03-22",

--- a/content/projects/claude-statusline.json
+++ b/content/projects/claude-statusline.json
@@ -1,6 +1,6 @@
 {
   "title": "Claude Statusline",
-  "description": "Multi-line status line for Claude Code. Shows repo, GitButler/git branch, model, session and daily cost, rate-limit progress, and context/token usage across four lines.",
+  "description": "Multi-line status line for Claude Code. Shows repo, GitButler/git branch, model + effort, session and daily cost, rate-limit progress, and context/token usage across four lines.",
   "href": "https://github.com/GordonBeeming/claude-statusline",
   "imgSrc": "/static/images/projects/claude-statusline.png",
   "techStack": [


### PR DESCRIPTION
## Summary

- rename the project card from “Claude / Codex Statusline” to “Claude Statusline”
- remove the incorrect Codex sibling claim from the description
- remove Codex from the project technology tags

## Why

The linked statusline project is for Claude Code only, so the portfolio card should not present it as a Codex project.

## User impact

Visitors now see accurate product scope and technology metadata for Claude Statusline.

## Validation

- `jq empty content/projects/claude-statusline.json`
- `git diff --check`
- `pnpm build`