### PR TITLE
Fix images 404ing on the deployed site (TinaCloud media rewrite)

### DIFF
--- a/src/app/about/client-author.tsx
+++ b/src/app/about/client-author.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTina, tinaField } from "tinacms/dist/react";
+import { normalizeTinaImages } from "@/components/tina/normalize-images";
 import { AboutView, type AboutTinaFields } from "./AboutView";
 import type { AuthorData, SiteConfig } from "@/lib/tina-helpers";
 import type { AuthorQuery } from "../../../tina/__generated__/types";
@@ -23,7 +24,11 @@ interface ClientAuthorProps {
  * avatar, profile lines, company/MVP logos) is live.
  */
 export function ClientAuthor({ query, variables, data, fallbackAuthor, siteConfig }: ClientAuthorProps) {
-  const { data: live } = useTina({ query, variables, data });
+  // In edit mode `useTina` refetches live from TinaCloud, bypassing the
+  // normalization `fetchTina` applied to the initial data — so re-normalize here
+  // to keep the admin image preview pointing at the same-origin repo paths.
+  const { data: liveRaw } = useTina({ query, variables, data });
+  const live = normalizeTinaImages(liveRaw);
   const author = live.author;
 
   const mergedAuthor: AuthorData = {

--- a/src/app/books/[slug]/client-book.tsx
+++ b/src/app/books/[slug]/client-book.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useTina, tinaField } from "tinacms/dist/react";
+import { normalizeTinaImages } from "@/components/tina/normalize-images";
 import { Button } from "@/components/ds/Button";
 import { Card } from "@/components/ds/Card";
 import type { BookQuery } from "../../../../tina/__generated__/types";
@@ -46,7 +47,11 @@ interface ClientBookProps {
  * from live data here.
  */
 export function ClientBook({ query, variables, data }: ClientBookProps) {
-  const { data: live } = useTina({ query, variables, data });
+  // Re-normalize the live data: edit-mode `useTina` refetches from TinaCloud and
+  // bypasses `fetchTina`, which would otherwise reintroduce the dead
+  // assets.tina.io cover-image URLs in the admin preview.
+  const { data: liveRaw } = useTina({ query, variables, data });
+  const live = normalizeTinaImages(liveRaw);
   const book = live.book;
   const authors = (book.authors ?? []).filter((a): a is NonNullable<typeof a> => a !== null);
   const reviewers = (book.reviewers ?? []).filter((r): r is NonNullable<typeof r> => r !== null);

--- a/src/app/projects/[slug]/client-project.tsx
+++ b/src/app/projects/[slug]/client-project.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTina, tinaField } from "tinacms/dist/react";
+import { normalizeTinaImages } from "@/components/tina/normalize-images";
 import { Tag } from "@/components/ds/Tag";
 import { Badge } from "@/components/ds/Badge";
 import { StarCount } from "@/components/ds/StarCount";
@@ -43,7 +44,11 @@ interface ClientProjectProps {
  * it stays outside this component entirely, rendered by page.tsx.
  */
 export function ClientProject({ query, variables, data, githubStars }: ClientProjectProps) {
-  const { data: live } = useTina({ query, variables, data });
+  // Re-normalize the live data: edit-mode `useTina` refetches from TinaCloud and
+  // bypasses `fetchTina`, which would otherwise reintroduce the dead
+  // assets.tina.io image URL in the admin preview.
+  const { data: liveRaw } = useTina({ query, variables, data });
+  const live = normalizeTinaImages(liveRaw);
   const project = live.project;
   const techStack = (project.techStack ?? []).filter((t): t is string => typeof t === "string");
 

--- a/src/components/tina/fetch.ts
+++ b/src/components/tina/fetch.ts
@@ -1,4 +1,5 @@
 import client from "../../../tina/__generated__/client";
+import { normalizeTinaImages } from "./normalize-images";
 
 /**
  * The generated Tina GraphQL client, re-exported from a stable `@/` path so
@@ -39,7 +40,9 @@ export async function fetchTina<
     return {
       query: result.query,
       variables: result.variables as Record<string, unknown>,
-      data: result.data,
+      // TinaCloud rewrites image fields to dead assets.tina.io URLs; restore the
+      // same-origin repo paths that actually serve the files. See normalize-images.ts.
+      data: normalizeTinaImages(result.data),
     };
   } catch (error) {
     if (isServerUnreachable(error)) {

--- a/src/components/tina/normalize-images.ts
+++ b/src/components/tina/normalize-images.ts
@@ -15,7 +15,8 @@ const CDN_PREFIX = CLIENT_ID ? `https://assets.tina.io/${CLIENT_ID}/` : "";
  *  paths) pass through unchanged. */
 export function normalizeTinaImageUrl(value: string): string {
   if (CDN_PREFIX && value.startsWith(CDN_PREFIX)) {
-    return "/" + value.slice(CDN_PREFIX.length);
+    const path = value.slice(CDN_PREFIX.length);
+    return path.startsWith("/") ? path : "/" + path;
   }
   return value;
 }
@@ -23,10 +24,17 @@ export function normalizeTinaImageUrl(value: string): string {
 function walk(value: unknown): unknown {
   if (typeof value === "string") return normalizeTinaImageUrl(value);
   if (Array.isArray(value)) return value.map(walk);
+  // Only recurse into plain objects — the TinaCloud response is parsed JSON, so this
+  // is always true in practice, but guarding the prototype stops a Date/RegExp/Map/Set
+  // (or other non-plain object) from being silently flattened into `{}` if one ever
+  // ends up in the tree.
   if (value !== null && typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [key, val] of Object.entries(value)) out[key] = walk(val);
-    return out;
+    const proto = Object.getPrototypeOf(value);
+    if (proto === null || proto === Object.prototype) {
+      const out: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(value)) out[key] = walk(val);
+      return out;
+    }
   }
   return value;
 }

--- a/src/components/tina/normalize-images.ts
+++ b/src/components/tina/normalize-images.ts
@@ -32,7 +32,12 @@ function walk(value: unknown): unknown {
     const proto = Object.getPrototypeOf(value);
     if (proto === null || proto === Object.prototype) {
       const out: Record<string, unknown> = {};
-      for (const [key, val] of Object.entries(value)) out[key] = walk(val);
+      for (const [key, val] of Object.entries(value)) {
+        // Tina's internal metadata (_sys, _values, __typename, __tina_metadata) has no
+        // image fields, and `_values` duplicates the entire raw document — skip walking
+        // it so normalization stays cheap.
+        out[key] = key.startsWith("_") ? val : walk(val);
+      }
       return out;
     }
   }

--- a/src/components/tina/normalize-images.ts
+++ b/src/components/tina/normalize-images.ts
@@ -1,0 +1,43 @@
+// TinaCloud resolves every `type: "image"` field through its media CDN, turning
+// a repo path like `/static/images/ssw-logo-light.png` into
+// `https://assets.tina.io/<clientId>/static/images/ssw-logo-light.png`. Our
+// images are committed repo files served same-origin (GitHub Pages), never
+// uploaded to Tina media — so those CDN URLs 404 on the built site. Stripping
+// the CDN prefix returns the field to its original same-origin path, which is
+// what actually serves the file. Local dev never produces these URLs (the
+// filesystem fallback keeps raw paths), so this is a no-op there.
+
+const CLIENT_ID = process.env.NEXT_PUBLIC_TINA_CLIENT_ID ?? "";
+const CDN_PREFIX = CLIENT_ID ? `https://assets.tina.io/${CLIENT_ID}/` : "";
+
+/** A single field value: strip the TinaCloud media-CDN prefix back to the
+ *  same-origin repo path. Non-matching strings (foreign URLs, already-relative
+ *  paths) pass through unchanged. */
+export function normalizeTinaImageUrl(value: string): string {
+  if (CDN_PREFIX && value.startsWith(CDN_PREFIX)) {
+    return "/" + value.slice(CDN_PREFIX.length);
+  }
+  return value;
+}
+
+function walk(value: unknown): unknown {
+  if (typeof value === "string") return normalizeTinaImageUrl(value);
+  if (Array.isArray(value)) return value.map(walk);
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) out[key] = walk(val);
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Deep-clone a TinaCloud response, rewriting every string leaf through
+ * {@link normalizeTinaImageUrl}. Structure and non-string leaves are preserved,
+ * so the generic type is retained — the lone `as T` is sound because `walk`
+ * only ever replaces a string with another string. Input is not mutated.
+ */
+export function normalizeTinaImages<T>(data: T): T {
+  if (!CDN_PREFIX) return data;
+  return walk(data) as T;
+}

--- a/src/components/tina/normalize-images.ts
+++ b/src/components/tina/normalize-images.ts
@@ -45,10 +45,12 @@ function walk(value: unknown): unknown {
 }
 
 /**
- * Deep-clone a TinaCloud response, rewriting every string leaf through
- * {@link normalizeTinaImageUrl}. Structure and non-string leaves are preserved,
- * so the generic type is retained — the lone `as T` is sound because `walk`
- * only ever replaces a string with another string. Input is not mutated.
+ * Rewrite every string leaf of a TinaCloud response through
+ * {@link normalizeTinaImageUrl}, returning a deep-cloned copy with structure and
+ * non-string leaves preserved — the lone `as T` is sound because `walk` only ever
+ * replaces a string with another string. When no client ID is configured (local
+ * dev, where these CDN URLs never appear) it short-circuits and returns the input
+ * unchanged. Input is never mutated.
  */
 export function normalizeTinaImages<T>(data: T): T {
   if (!CDN_PREFIX) return data;


### PR DESCRIPTION
## What was broken

After #274, images stopped loading on the deployed site — the SSW/MVP logos on `/about`, book covers, and project images all showed the broken-image icon. Local dev looked fine, which is what made it confusing.

## Root cause

Every `type: "image"` field in `tina/config.ts` holds a repo-committed path like `/static/images/ssw-logo-light.png`. The production build runs `pnpm build:tina` with the TinaCloud credentials, so page data is fetched from TinaCloud at build time — and TinaCloud rewrites every image field to its media CDN:

```
https://assets.tina.io/<clientId>/static/images/ssw-logo-light.png  ->  404
```

Those images were never uploaded to Tina's media store (they're plain repo files served same-origin by GitHub Pages), so the CDN URL 404s. Local builds never hit this because the generated client points at `localhost:4001`, which is down during the build, so `fetchTina` falls back to the filesystem and keeps the raw paths.

The avatar *looked* fine only because `AboutView` renders it as a `<video>` from a hardcoded non-Tina path; the logos have no such fallback.

## The fix

`normalizeTinaImages()` strips the `assets.tina.io/<clientId>/` prefix back to the same-origin repo path (a no-op locally, where the URLs never appear). It's applied at the single `fetchTina` boundary, so every collection is covered at once, and re-applied to the `useTina` result in the client wrappers so the admin edit-mode preview stays correct too.

No `tina/config.ts` change, so no `tina-lock.json` regen.

## Verification

Ran a real TinaCloud build (`build:tina`, generated client pointed at `content.tinajs.io`): the built `/about` and book pages now emit `/static/images/*`, and a grep across all built HTML finds zero surviving `assets.tina.io` image URLs. Same-origin targets already serve 200.

## Related (separate repo)

The mirrored-README badges on project pages (`github.com`, `img.shields.io`) are blocked by the Cloudflare Worker CSP `img-src`. Fixed in `cloudflare-xylem-worker` (`src/index.js`) by allowing the GitHub/shields image hosts — that repo needs its own deploy, and a Cloudflare cache purge, to take effect.