### PR TITLE
Theme mermaid diagrams to the site (dark/light) instead of hardcoded colors

### DIFF
--- a/src/components/prose/MermaidDiagram.tsx
+++ b/src/components/prose/MermaidDiagram.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useTheme } from "next-themes";
 import mermaid from "mermaid";
+import { stripMermaidColors } from "@/lib/mermaid-theme";
 
 interface MermaidDiagramProps {
   chart: string;
@@ -51,6 +52,13 @@ function initMermaidForTheme(isDark: boolean) {
           activationBkgColor: "#132e34",
           activationBorderColor: "#22d3ee",
           sequenceNumberColor: "#04252e",
+          // Subgraph (cluster) chrome — mermaid's base defaults render these
+          // near-black, so the solid + dashed grouping boxes vanished on the
+          // dark card. A light slate border reads as a grouping boundary,
+          // distinct from the cyan node borders.
+          clusterBkg: "#0f1c2e",
+          clusterBorder: "#8595ad",
+          titleColor: "#e8eef6",
         }
       : {
           primaryColor: "#e7f6f8",
@@ -78,6 +86,11 @@ function initMermaidForTheme(isDark: boolean) {
           activationBkgColor: "#e7f6f8",
           activationBorderColor: "#0e7490",
           sequenceNumberColor: "#ffffff",
+          // See dark-theme note above — a mid-slate boundary keeps the solid +
+          // dashed subgraph boxes visible on the light card.
+          clusterBkg: "#f1f5f9",
+          clusterBorder: "#64748b",
+          titleColor: "#0f172a",
         },
     flowchart: { useMaxWidth: true },
     sequence: { useMaxWidth: true },
@@ -100,7 +113,7 @@ export function MermaidDiagram({ chart, title }: MermaidDiagramProps) {
     initMermaidForTheme(isDark);
 
     try {
-      const result = await mermaid.render(id, chart.trim());
+      const result = await mermaid.render(id, stripMermaidColors(chart.trim()));
       if (signal.cancelled) return;
 
       bindFunctionsRef.current = result.bindFunctions ?? null;

--- a/src/lib/mermaid-theme.ts
+++ b/src/lib/mermaid-theme.ts
@@ -69,7 +69,10 @@ export function stripMermaidColors(chart: string): string {
           const key = prop.slice(0, colonIdx).trim().toLowerCase();
           const value = prop.slice(colonIdx + 1).trim().toLowerCase();
           if (!COLOR_KEYS.has(key)) return true;
-          return PRESERVED_VALUES.has(value);
+          if (PRESERVED_VALUES.has(value)) return true;
+          // var()/url() are dynamic/theme-friendly, not hardcoded colors —
+          // stripping them would defeat the point of this helper.
+          return value.includes("var(") || value.startsWith("url(");
         });
 
       // All props were colors → the directive has nothing left to say, drop it.

--- a/src/lib/mermaid-theme.ts
+++ b/src/lib/mermaid-theme.ts
@@ -46,14 +46,24 @@ export function stripMermaidColors(chart: string): string {
 
       const [, indent, keyword, target, propsPart] = match;
 
-      // ponytail: top-level comma split handles rgb()/hsl() and a trailing
-      // `;`. A bare comma inside a non-paren value (e.g. `stroke-dasharray: 5,
-      // 5` instead of the normal space-separated form) would still mis-split
-      // — worst case a harmless stray token, not corruption. Swap in a real
-      // tokenizer only if a README ever needs that.
-      const kept = splitTopLevelCommas(propsPart.trim().replace(/;+$/, ""))
+      const cleaned = propsPart.trim().replace(/;+$/, "");
+      // Mermaid allows multiple `;`-separated statements on one line
+      // (`style A fill:#fff; style B fill:#000`). A leftover `;` after
+      // stripping the trailing one means this line has more than one
+      // statement — parsing that needs a real tokenizer, so leave the whole
+      // line untouched rather than risk mangling the later statement.
+      if (cleaned.includes(";")) return line;
+
+      // ponytail: top-level comma split handles rgb()/hsl(), a trailing `;`,
+      // and empty segments; multi-statement lines are passed through above
+      // rather than parsed. A bare comma inside a non-paren value (e.g.
+      // `stroke-dasharray: 5, 5` instead of the normal space-separated form)
+      // would still mis-split — worst case a harmless stray token, not
+      // corruption. Swap in a real tokenizer only if a README ever needs that.
+      const kept = splitTopLevelCommas(cleaned)
         .map((p) => p.trim())
         .filter((prop) => {
+          if (!prop) return false; // empty segment from a trailing/double comma
           const colonIdx = prop.indexOf(":");
           if (colonIdx === -1) return true; // not a key:value pair, leave it
           const key = prop.slice(0, colonIdx).trim().toLowerCase();

--- a/src/lib/mermaid-theme.ts
+++ b/src/lib/mermaid-theme.ts
@@ -10,6 +10,25 @@ const PRESERVED_VALUES = new Set(["none", "transparent", "inherit"]);
 
 const DIRECTIVE = /^(\s*)(style|linkStyle|classDef)\s+(\S+)\s+(.*)$/;
 
+// Splits a props list on top-level commas only, so a comma inside a color
+// function (`rgb(0,0,0)`, `hsl(210, 50%, 40%)`) doesn't shatter the value.
+function splitTopLevelCommas(props: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < props.length; i++) {
+    const char = props[i];
+    if (char === "(") depth++;
+    else if (char === ")") depth = Math.max(0, depth - 1);
+    else if (char === "," && depth === 0) {
+      parts.push(props.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(props.slice(start));
+  return parts;
+}
+
 /**
  * Strip hardcoded colors from a mermaid chart's inline `style`/`linkStyle`/
  * `classDef` directives so the site's theme variables drive all coloring.
@@ -27,11 +46,12 @@ export function stripMermaidColors(chart: string): string {
 
       const [, indent, keyword, target, propsPart] = match;
 
-      // ponytail: props split on commas; a value containing its own comma
-      // (rare, e.g. `stroke-dasharray: 5, 5`) would mis-split — swap in a real
-      // tokenizer only if a README ever needs it.
-      const kept = propsPart
-        .split(",")
+      // ponytail: top-level comma split handles rgb()/hsl() and a trailing
+      // `;`. A bare comma inside a non-paren value (e.g. `stroke-dasharray: 5,
+      // 5` instead of the normal space-separated form) would still mis-split
+      // — worst case a harmless stray token, not corruption. Swap in a real
+      // tokenizer only if a README ever needs that.
+      const kept = splitTopLevelCommas(propsPart.trim().replace(/;+$/, ""))
         .map((p) => p.trim())
         .filter((prop) => {
           const colonIdx = prop.indexOf(":");

--- a/src/lib/mermaid-theme.ts
+++ b/src/lib/mermaid-theme.ts
@@ -1,0 +1,52 @@
+// Color-bearing property keys in a mermaid `style`/`linkStyle`/`classDef`
+// directive. `stroke-width` / `stroke-dasharray` are deliberately absent — they
+// carry structure (border weight, dashes), not color, and must survive.
+const COLOR_KEYS = new Set(["fill", "stroke", "color", "background", "background-color"]);
+
+// Values that express structural intent rather than a concrete color. Preserving
+// `none` keeps an intentionally invisible node (e.g. `fill:none,stroke:none`)
+// invisible instead of letting the theme fill it in.
+const PRESERVED_VALUES = new Set(["none", "transparent", "inherit"]);
+
+const DIRECTIVE = /^(\s*)(style|linkStyle|classDef)\s+(\S+)\s+(.*)$/;
+
+/**
+ * Strip hardcoded colors from a mermaid chart's inline `style`/`linkStyle`/
+ * `classDef` directives so the site's theme variables drive all coloring.
+ *
+ * Project READMEs (rendered from committed markdown) sometimes hardcode light
+ * hex fills that clash with the dark site — this neutralizes those while leaving
+ * structure (shapes, dashed borders, stroke widths, invisible nodes) intact.
+ */
+export function stripMermaidColors(chart: string): string {
+  return chart
+    .split("\n")
+    .map((line) => {
+      const match = DIRECTIVE.exec(line);
+      if (!match) return line;
+
+      const [, indent, keyword, target, propsPart] = match;
+
+      // ponytail: props split on commas; a value containing its own comma
+      // (rare, e.g. `stroke-dasharray: 5, 5`) would mis-split — swap in a real
+      // tokenizer only if a README ever needs it.
+      const kept = propsPart
+        .split(",")
+        .map((p) => p.trim())
+        .filter((prop) => {
+          const colonIdx = prop.indexOf(":");
+          if (colonIdx === -1) return true; // not a key:value pair, leave it
+          const key = prop.slice(0, colonIdx).trim().toLowerCase();
+          const value = prop.slice(colonIdx + 1).trim().toLowerCase();
+          if (!COLOR_KEYS.has(key)) return true;
+          return PRESERVED_VALUES.has(value);
+        });
+
+      // All props were colors → the directive has nothing left to say, drop it.
+      if (kept.length === 0) return null;
+
+      return `${indent}${keyword} ${target} ${kept.join(",")}`;
+    })
+    .filter((line) => line !== null)
+    .join("\n");
+}

--- a/src/lib/mermaid-theme.ts
+++ b/src/lib/mermaid-theme.ts
@@ -6,7 +6,7 @@ const COLOR_KEYS = new Set(["fill", "stroke", "color", "background", "background
 // Values that express structural intent rather than a concrete color. Preserving
 // `none` keeps an intentionally invisible node (e.g. `fill:none,stroke:none`)
 // invisible instead of letting the theme fill it in.
-const PRESERVED_VALUES = new Set(["none", "transparent", "inherit"]);
+const PRESERVED_VALUES = new Set(["none", "transparent", "inherit", "currentcolor", "initial", "unset"]);
 
 const DIRECTIVE = /^(\s*)(style|linkStyle|classDef)\s+(\S+)\s+(.*)$/;
 
@@ -39,7 +39,7 @@ function splitTopLevelCommas(props: string): string[] {
  */
 export function stripMermaidColors(chart: string): string {
   return chart
-    .split("\n")
+    .split(/\r?\n/)
     .map((line) => {
       const match = DIRECTIVE.exec(line);
       if (!match) return line;


### PR DESCRIPTION
## Summary

The Network Topology diagram on `/projects/copilot-here` (and the identical one in the 2025-11-28 blog post) rendered as light boxes with light-on-light text on the dark site. The source README hardcodes hex colors in the mermaid `style`/`linkStyle` directives, and those inline colors override the theme our `MermaidDiagram` component already sets.

Two changes, both at render time so the source READMEs stay untouched (GitHub renders them with its own themes):

- **New `stripMermaidColors` helper** (`src/lib/mermaid-theme.ts`) drops hardcoded `fill`/`stroke`/`color`/`background` from `style`/`linkStyle`/`classDef` directives before the chart renders. It keeps `stroke-width`, `stroke-dasharray`, and `none`, so structure survives (dashed airlock border, invisible `eth0` node) while the site theme drives every color, for this diagram and every future project-README or blog mermaid. Props are split on top-level commas only, so a color function like `rgb(0,0,0)` doesn't shatter into stray fragments, a trailing `;` is stripped before matching preserved values, empty comma segments are dropped instead of left as litter, and a multi-statement line (`style A fill:#fff; style B fill:#000`) is passed through untouched rather than parsed.
- **Cluster theming** — added `clusterBkg`/`clusterBorder`/`titleColor` to the dark and light `themeVariables` in `MermaidDiagram.tsx`. Mermaid's base defaults render subgraph boxes near-black, so the solid and dashed grouping outlines had vanished on the dark card; a slate boundary makes them read as groupings, distinct from the cyan node borders.

## Test plan

- Assertion check on `stripMermaidColors`: keeps `stroke-width`/`stroke-dasharray`/`none`, drops the hex colors, drops an all-color directive entirely, keeps a structural prop after a stripped `rgb()` color intact, handles a trailing `;` without losing `fill:none`, drops empty segments from a trailing/double comma without litter, and passes a multi-statement line through unchanged.
- Rendered `/projects/copilot-here` in both themes and measured contrast: node text 12–18:1, cluster borders 6.19:1 (dark) / 4.41:1 (light). Confirmed the dashed airlock border and the invisible `eth0` node still render correctly.

No linked issue.
