### PR TITLE
Add MyTerm to projects

### DIFF
--- a/content/projects/myterm.json
+++ b/content/projects/myterm.json
@@ -1,0 +1,14 @@
+{
+  "title": "MyTerm",
+  "description": "An opinionated native macOS terminal for people who keep several projects open all day. It keeps long-lived terminal sessions and WebKit browser tabs inside named workspaces, with fast pane splitting and very little surrounding UI.",
+  "techStack": [
+    "Swift",
+    "SwiftUI",
+    "SwiftTerm",
+    "WebKit",
+    "macOS"
+  ],
+  "github": "https://github.com/GordonBeeming/myterm",
+  "date": "2026-07-21",
+  "featured": false
+}


### PR DESCRIPTION
## Summary

- Add MyTerm to the projects collection.
- Describe its native macOS terminal, workspace, pane, and browser-tab experience.
- Include the public GitHub repository and core Swift/macOS technology stack.

## Why

MyTerm is now a public project and should appear alongside the other projects on the site.

## User impact

Visitors to the projects page can discover MyTerm and follow its repository link.

## Validation

- Parsed `content/projects/myterm.json` successfully with Node.js.
- Ran `git diff --check` for the project entry.
- Rendered the projects page locally and confirmed the MyTerm card appears once without overflow or encoding issues.